### PR TITLE
feat: add media download support and card render mode

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -24,11 +24,14 @@ const DmConfigSchema = z
 
 const MarkdownConfigSchema = z
   .object({
-    mode: z.enum(["native", "escape", "strip"]).optional(),
+    mode: z.enum(["native", "escape", "strip", "raw", "card"]).optional(),
     tableMode: z.enum(["native", "ascii", "simple"]).optional(),
   })
   .strict()
   .optional();
+
+// Message render mode: raw = plain text, card = interactive card with markdown
+const MessageRenderModeSchema = z.enum(["raw", "card"]).optional();
 
 const BlockStreamingCoalesceSchema = z
   .object({
@@ -86,6 +89,8 @@ export const FeishuConfigSchema = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema,
     mediaMaxMb: z.number().positive().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    downloadDir: z.string().optional(), // Directory for downloaded media files
+    renderMode: MessageRenderModeSchema, // raw = plain text, card = interactive card with markdown
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/src/send.ts
+++ b/src/send.ts
@@ -273,3 +273,36 @@ export async function editMessageFeishu(params: {
     throw new Error(`Feishu message edit failed: ${response.msg || `code ${response.code}`}`);
   }
 }
+
+/**
+ * Build a Feishu interactive card from markdown text.
+ * The card will render markdown properly.
+ */
+export function buildMarkdownCard(text: string): Record<string, unknown> {
+  return {
+    config: {
+      wide_screen_mode: true,
+    },
+    elements: [
+      {
+        tag: "markdown",
+        content: text,
+      },
+    ],
+  };
+}
+
+/**
+ * Send a message as a markdown card (interactive message).
+ * This renders markdown properly in Feishu.
+ */
+export async function sendMarkdownCardFeishu(params: {
+  cfg: ClawdbotConfig;
+  to: string;
+  text: string;
+  replyToMessageId?: string;
+}): Promise<FeishuSendResult> {
+  const { cfg, to, text, replyToMessageId } = params;
+  const card = buildMarkdownCard(text);
+  return sendCardFeishu({ cfg, to, card, replyToMessageId });
+}


### PR DESCRIPTION
## Summary

This PR adds support for downloading media files (images, files, audio) from Feishu messages and saving them to local paths for AI processing. It also adds a card render mode for better markdown rendering.

## Changes

### Media Download
- `downloadImageFeishu`: Download standalone images
- `downloadFileFeishu`: Download files (Excel, Word, PDF, etc.)
- `downloadAudioFeishu`: Download audio messages
- `downloadMessageResourceFeishu`: Download embedded images in rich text (post) messages
- `parseMessageContentAsync`: Parse non-text messages and download media automatically

### Card Render Mode
- `renderMode` config option: `raw` (default) or `card`
- `sendMarkdownCardFeishu`: Send messages as interactive cards with markdown rendering
- `buildMarkdownCard`: Helper to build card structure

### Config Options
- `downloadDir`: Custom directory for downloaded files (default: `$CLAWD_WORKSPACE/downloads/feishu`)
- `renderMode`: Choose between plain text (`raw`) or interactive card (`card`) for message rendering

## Usage

```yaml
channels:
  feishu:
    downloadDir: /path/to/downloads
    renderMode: card  # or raw
```

When a user sends an image or file, the plugin will:
1. Download the file to local storage
2. Pass the file path to the AI in the message
3. AI can then use its tools (read, exec) to process the file

## Testing

Tested with:
- Images in rich text (post) messages ✅
- Standalone file messages (Excel) ✅
- Card render mode with markdown ✅