### PR TITLE
feat: download inbound media so images work

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -85,6 +85,8 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         textChunkLimit: { type: "integer", minimum: 1 },
         chunkMode: { type: "string", enum: ["length", "newline"] },
         mediaMaxMb: { type: "number", minimum: 0 },
+        downloadInboundMedia: { type: "boolean" },
+        inboundMediaDir: { type: "string" },
       },
     },
   },

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -85,6 +85,12 @@ export const FeishuConfigSchema = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema,
     mediaMaxMb: z.number().positive().optional(),
+
+    // When enabled, download inbound image/file payloads to local disk and pass
+    // them to Clawdbot as MediaPath/MediaType for media understanding.
+    downloadInboundMedia: z.boolean().optional().default(false),
+    inboundMediaDir: z.string().optional().default("/home/ubuntu/.clawdbot/cache/feishu-media"),
+
     heartbeat: ChannelHeartbeatVisibilitySchema,
   })
   .strict()


### PR DESCRIPTION
### What\nThis PR adds optional inbound media hydration for the Feishu/Lark channel. When enabled, the plugin downloads image/file resources referenced in incoming messages and forwards the local MediaPath/MediaType into Clawdbot so media understanding (image) can run.\n\n### Why\nFeishu inbound image/file messages often contain only a key (image_key/file_key). Without downloading, the gateway cannot pass the actual bytes to the model.\n\n### Changes\n- Add  (default false)\n- Add  (default /home/ubuntu/.clawdbot/cache/feishu-media)\n- Handle inbound media in  for message types: , , and rich  (img blocks)\n- Download via  **with required query param **\n\n### Notes\n- Only minimal logging added for debugging; can be reduced if preferred.\n- This does not include any user-specific secrets/config.\n