### PR TITLE
fix: support video/media message type download

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -162,8 +162,9 @@ function parseMediaKeys(
       case "audio":
         return { fileKey: parsed.file_key };
       case "video":
-        // Video has both file_key (video) and image_key (thumbnail)
-        return { fileKey: parsed.file_key, imageKey: parsed.image_key };
+      case "media":
+        // Video/media has both file_key (video) and image_key (thumbnail)
+        return { fileKey: parsed.file_key, imageKey: parsed.image_key, fileName: parsed.file_name };
       case "sticker":
         return { fileKey: parsed.file_key };
       default:
@@ -230,6 +231,7 @@ function inferPlaceholder(messageType: string): string {
     case "audio":
       return "<media:audio>";
     case "video":
+    case "media":
       return "<media:video>";
     case "sticker":
       return "<media:sticker>";
@@ -253,7 +255,7 @@ async function resolveFeishuMediaList(params: {
   const { cfg, messageId, messageType, content, maxBytes, log } = params;
 
   // Only process media message types (including post for embedded images)
-  const mediaTypes = ["image", "file", "audio", "video", "sticker", "post"];
+  const mediaTypes = ["image", "file", "audio", "video", "media", "sticker", "post"];
   if (!mediaTypes.includes(messageType)) {
     return [];
   }
@@ -320,7 +322,11 @@ async function resolveFeishuMediaList(params: {
 
     // For message media, always use messageResource API
     // The image.get API is only for images uploaded via im/v1/images, not for message attachments
-    const fileKey = mediaKeys.imageKey || mediaKeys.fileKey;
+    // For video/media messages, prefer file_key (actual video) over image_key (thumbnail)
+    const isVideoType = messageType === "video" || messageType === "media";
+    const fileKey = isVideoType 
+      ? (mediaKeys.fileKey || mediaKeys.imageKey)
+      : (mediaKeys.imageKey || mediaKeys.fileKey);
     if (!fileKey) {
       return [];
     }


### PR DESCRIPTION
## Problem

Video messages sent from Feishu client cannot be downloaded correctly. The plugin only receives raw JSON instead of the actual video file.

## Root Cause

1. Feishu sends video messages with `message_type: "media"` instead of `"video"`. The existing code did not handle the `media` type.
2. The code prioritized `image_key` (thumbnail) over `file_key` (actual video file), resulting in downloading the thumbnail instead of the video.

## Changes

### `src/bot.ts`

1. **`parseMediaKeys()`** - Added `media` case to handle video messages:
   ```typescript
   case "video":
   case "media":
     return { fileKey: parsed.file_key, imageKey: parsed.image_key, fileName: parsed.file_name };
   ```

2. **`inferPlaceholder()`** - Added `media` type mapping:
   ```typescript
   case "video":
   case "media":
     return "<media:video>";
   ```

3. **`resolveFeishuMediaList()`** - Added `media` to supported media types:
   ```typescript
   const mediaTypes = ["image", "file", "audio", "video", "media", "sticker", "post"];
   ```

4. **`resolveFeishuMediaList()`** - For video/media types, prefer `file_key` over `image_key`:
   ```typescript
   const isVideoType = messageType === "video" || messageType === "media";
   const fileKey = isVideoType 
     ? (mediaKeys.fileKey || mediaKeys.imageKey)
     : (mediaKeys.imageKey || mediaKeys.fileKey);
   ```

## Testing

- ✅ Image messages download correctly
- ✅ Video messages (media type) download the actual video file, not thumbnail
- ✅ File name is preserved in downloaded video