### PR TITLE
feat: add AI vision support by passing image attachments to model

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type FeishuMessageContext = {
   parentId?: string;
   content: string;
   contentType: string;
+  imageKey?: string;
 };
 
 export type FeishuSendResult = {


### PR DESCRIPTION
This commit adds support for passing image attachments to the AI model for vision capabilities in Feishu/Lark conversations.

Changes:
- Add imageKey field to FeishuMessageContext type
- Extract image_key from image messages in parseFeishuMessageEvent()
- Download images using downloadMessageResourceFeishu() API
- Create Attachments array with Buffer data and MIME types
- Pass Attachments field to AI model via context payload
- Download and include images from quoted/replied messages
- Add debug logging for attachment information

Technical details:
- Uses existing downloadMessageResourceFeishu() function
- Detects MIME types using core.media.detectMime()
- Handles both current message images and quoted message images
- Graceful error handling with detailed logging

This implementation complements the existing MediaPath-based media handling system by providing direct Buffer-based attachments for AI vision capabilities.