### PR TITLE
fix install error due to openclaw rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ai",
     "claude"
   ],
-  "clawdbot": {
+  "openclaw": {
     "extensions": [
       "./index.ts"
     ],


### PR DESCRIPTION
fix install error due to openclaw rename

root@a8c7766c3102:~/.openclaw# openclaw plugins install ./feishu.tgz 

🦞 OpenClaw 2026.1.29 (613724c) — Type the command with confidence—nature will provide the stack trace if needed.

Extracting /root/.openclaw/feishu.tgz…
Error: package.json missing openclaw.extensions