### PR TITLE
fix(feishu): match msg_type to uploaded file_type for mp4/opus

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -6,6 +6,10 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import { Readable } from "stream";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
 
 export type DownloadImageResult = {
   buffer: Buffer;
@@ -349,9 +353,10 @@ async function sendUploadedFileLikeMessageFeishu(params: {
   to: string;
   fileKey: string;
   msgType: "file" | "audio" | "media";
+  imageKey?: string; // for msg_type=media
   replyToMessageId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, fileKey, msgType, replyToMessageId } = params;
+  const { cfg, to, fileKey, msgType, imageKey, replyToMessageId } = params;
 
   const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
   if (!feishuCfg) {
@@ -365,7 +370,10 @@ async function sendUploadedFileLikeMessageFeishu(params: {
   }
 
   const receiveIdType = resolveReceiveIdType(receiveId);
-  const content = JSON.stringify({ file_key: fileKey });
+  const content = JSON.stringify({
+    file_key: fileKey,
+    ...(msgType === "media" && imageKey ? { image_key: imageKey } : {}),
+  });
 
   if (replyToMessageId) {
     const response = await client.im.message.reply({
@@ -454,13 +462,15 @@ export async function sendVideoFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
+  imageKey?: string;
   replyToMessageId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, fileKey, replyToMessageId } = params;
+  const { cfg, to, fileKey, imageKey, replyToMessageId } = params;
   return sendUploadedFileLikeMessageFeishu({
     cfg,
     to,
     fileKey,
+    imageKey,
     msgType: "media",
     replyToMessageId,
   });
@@ -500,6 +510,50 @@ export function detectFileType(
 /**
  * Check if a string is a local file path (not a URL)
  */
+async function tryGetMediaDurationMs(filePath: string): Promise<number | undefined> {
+  try {
+    // ffprobe is commonly available alongside ffmpeg. If not present, we'll just omit duration.
+    const { stdout } = await execFileAsync("ffprobe", [
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "default=noprint_wrappers=1:nokey=1",
+      filePath,
+    ]);
+
+    const seconds = Number(String(stdout).trim());
+    if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
+    return Math.round(seconds * 1000);
+  } catch {
+    return undefined;
+  }
+}
+
+async function tryGenerateVideoThumbnailJpg(params: {
+  videoPath: string;
+  outPath: string;
+}): Promise<boolean> {
+  try {
+    // Generate a representative frame as cover image.
+    // We use the first frame to keep it deterministic.
+    await execFileAsync("ffmpeg", [
+      "-y",
+      "-i",
+      params.videoPath,
+      "-frames:v",
+      "1",
+      "-q:v",
+      "2",
+      params.outPath,
+    ]);
+    return fs.existsSync(params.outPath);
+  } catch {
+    return false;
+  }
+}
+
 function isLocalPath(urlOrPath: string): boolean {
   // Starts with / or ~ or drive letter (Windows)
   if (urlOrPath.startsWith("/") || urlOrPath.startsWith("~") || /^[a-zA-Z]:/.test(urlOrPath)) {
@@ -530,6 +584,10 @@ export async function sendMediaFeishu(params: {
   let buffer: Buffer;
   let name: string;
 
+  // Best-effort: keep a file path around so we can compute duration / thumbnail for video.
+  // If the input is a Buffer or remote URL, we may write a temporary file.
+  let localPath: string | undefined;
+
   if (mediaBuffer) {
     buffer = mediaBuffer;
     name = fileName ?? "file";
@@ -545,6 +603,7 @@ export async function sendMediaFeishu(params: {
       }
       buffer = fs.readFileSync(filePath);
       name = fileName ?? path.basename(filePath);
+      localPath = filePath;
     } else {
       // Remote URL - fetch
       const response = await fetch(mediaUrl);
@@ -568,20 +627,86 @@ export async function sendMediaFeishu(params: {
   }
 
   const fileType = detectFileType(name);
+
+  // Best-effort: provide duration for audio/video uploads.
+  // Feishu will display duration as 0 if duration is omitted.
+  let durationMs: number | undefined;
+  let tmpPath: string | undefined;
+
+  if (fileType === "mp4" || fileType === "opus") {
+    try {
+      const probePath = localPath;
+      if (probePath) {
+        durationMs = await tryGetMediaDurationMs(probePath);
+      } else {
+        tmpPath = path.join(os.tmpdir(), `feishu_media_${Date.now()}_${Math.random().toString(16).slice(2)}_${name}`);
+        await fs.promises.writeFile(tmpPath, buffer);
+        durationMs = await tryGetMediaDurationMs(tmpPath);
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  // Upload
   const { fileKey } = await uploadFileFeishu({
     cfg,
     file: buffer,
     fileName: name,
     fileType,
+    ...(durationMs !== undefined ? { duration: durationMs } : {}),
   });
 
+  // Cleanup temp probe file if we created one.
+  if (tmpPath) {
+    await fs.promises.unlink(tmpPath).catch(() => {});
+  }
+
   // Feishu requires msg_type to match the upload file_type.
-  // - file_type=mp4  -> msg_type=media
+  // - file_type=mp4  -> msg_type=media (and include image_key for cover if possible)
   // - file_type=opus -> msg_type=audio
   // - other          -> msg_type=file
   if (fileType === "mp4") {
-    return sendVideoFeishu({ cfg, to, fileKey, replyToMessageId });
+    // Best-effort: generate & upload a cover image so clients can render preview correctly.
+    let imageKey: string | undefined;
+    try {
+      const videoPath = localPath;
+      // If we don't have a local path, write a temp file for thumbnail generation.
+      const videoTmpPath = videoPath
+        ? undefined
+        : path.join(
+            os.tmpdir(),
+            `feishu_media_thumb_${Date.now()}_${Math.random().toString(16).slice(2)}_${name}`,
+          );
+
+      if (videoTmpPath) {
+        await fs.promises.writeFile(videoTmpPath, buffer);
+      }
+
+      const thumbPath = path.join(
+        os.tmpdir(),
+        `feishu_cover_${Date.now()}_${Math.random().toString(16).slice(2)}.jpg`,
+      );
+
+      const ok = await tryGenerateVideoThumbnailJpg({
+        videoPath: videoPath ?? videoTmpPath!,
+        outPath: thumbPath,
+      });
+
+      if (ok) {
+        const uploaded = await uploadImageFeishu({ cfg, image: thumbPath });
+        imageKey = uploaded.imageKey;
+      }
+
+      await fs.promises.unlink(thumbPath).catch(() => {});
+      if (videoTmpPath) await fs.promises.unlink(videoTmpPath).catch(() => {});
+    } catch {
+      // ignore
+    }
+
+    return sendVideoFeishu({ cfg, to, fileKey, imageKey, replyToMessageId });
   }
+
   if (fileType === "opus") {
     return sendAudioFeishu({ cfg, to, fileKey, replyToMessageId });
   }


### PR DESCRIPTION
# 脱敏测试报告：Feishu sendMediaFeishu 视频发送失败（230055）修复

## 背景
在调用 Feishu `im/v1/messages` 发送媒体时，出现 400 错误：
- code: **230055**
- msg: **The type of file upload does not match the type of message being sent.**

现象：上传返回的 `file_key` 在发送时使用了 `msg_type=file`，但实际上传类型为视频/音频时，Feishu 要求使用对应的 `msg_type`。

## 根因定位
插件中 `sendMediaFeishu()`：
- 对非图片文件统一走 `uploadFileFeishu()`
- **发送阶段固定使用 `msg_type="file"`**

当文件后缀为 `.mp4` 时：
- 上传使用 `file_type=mp4`
- 发送必须使用 `msg_type=media`

否则触发 230055。

## 修复内容
- 新增内部 helper `sendUploadedFileLikeMessageFeishu({ msgType })`，统一承载 message.create/reply 的发送逻辑。
- 新增：
  - `sendAudioFeishu()`：`msg_type=audio`
  - `sendVideoFeishu()`：`msg_type=media`
- 更新 `sendMediaFeishu()`：根据 `detectFileType()` 结果选择正确的 `msg_type`：
  - `mp4` -> `media`
  - `opus` -> `audio`
  - 其他 -> `file`

## 本地验证（脱敏）
### 用例：发送 mp4 视频
1. 生成 1 秒 mp4（蓝底 + 440Hz 音频），文件名：`test-video.mp4`
2. 通过 Clawdbot Feishu 渠道向一个 P2P 会话发送该 mp4

### 结果
- 视频消息发送成功（未再出现 230055）
- 返回：
  - messageId: `om_x100b58f374b97c94b321d7479c50509`
  - chatId: `ou_205cbb89e7a979ba2aa9534e285b8478`

### 脱敏说明
- 未包含任何 `Authorization/Bearer token`、app_secret、tenant_access_token 等敏感字段。
- 仅保留必要的错误码/现象描述与发送成功的 messageId/chatId（用于追踪）。
