### PR TITLE
fix: upgrade card format to schema 2.0 for proper markdown rendering

### DIFF
--- a/src/send.ts
+++ b/src/send.ts
@@ -241,18 +241,22 @@ export async function updateCardFeishu(params: {
 /**
  * Build a Feishu interactive card with markdown content.
  * Cards render markdown properly (code blocks, tables, links, etc.)
+ * Uses schema 2.0 format for proper markdown rendering.
  */
 export function buildMarkdownCard(text: string): Record<string, unknown> {
   return {
+    schema: "2.0",
     config: {
       wide_screen_mode: true,
     },
-    elements: [
-      {
-        tag: "markdown",
-        content: text,
-      },
-    ],
+    body: {
+      elements: [
+        {
+          tag: "markdown",
+          content: text,
+        },
+      ],
+    },
   };
 }
 


### PR DESCRIPTION
## Problem

The current card format does not render markdown content properly. Text appears as plain text instead of formatted markdown (bold, code blocks, tables, etc.).

## Solution

Upgrade to Feishu Card schema 2.0 format:
- Add `schema: "2.0"` to card structure
- Move `elements` array inside `body` object per schema 2.0 spec

## Reference

- [Feishu Card JSON v2 Documentation](https://open.feishu.cn/document/feishu-cards/card-json-v2-components/content-components/rich-text)

## Testing

Tested in production environment - markdown now renders correctly in Feishu messages.