### PR TITLE
fix: check group ID instead of sender ID for groupAllowFrom

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -448,17 +448,32 @@ export async function handleFeishuMessage(params: {
     const groupAllowFrom = feishuCfg?.groupAllowFrom ?? [];
     const groupConfig = resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId });
 
-    const senderAllowFrom = groupConfig?.allowFrom ?? groupAllowFrom;
-    const allowed = isFeishuGroupAllowed({
+    // Check if this GROUP is allowed (groupAllowFrom contains group IDs like oc_xxx, not user IDs)
+    const groupAllowed = isFeishuGroupAllowed({
       groupPolicy,
-      allowFrom: senderAllowFrom,
-      senderId: ctx.senderOpenId,
-      senderName: ctx.senderName,
+      allowFrom: groupAllowFrom,
+      senderId: ctx.chatId, // Check group ID, not sender ID
+      senderName: undefined,
     });
 
-    if (!allowed) {
-      log(`feishu: sender ${ctx.senderOpenId} not in group allowlist`);
+    if (!groupAllowed) {
+      log(`feishu: group ${ctx.chatId} not in allowlist`);
       return;
+    }
+
+    // Additional sender-level allowlist check if group has specific allowFrom config
+    const senderAllowFrom = groupConfig?.allowFrom ?? [];
+    if (senderAllowFrom.length > 0) {
+      const senderAllowed = isFeishuGroupAllowed({
+        groupPolicy: "allowlist",
+        allowFrom: senderAllowFrom,
+        senderId: ctx.senderOpenId,
+        senderName: ctx.senderName,
+      });
+      if (!senderAllowed) {
+        log(`feishu: sender ${ctx.senderOpenId} not in group ${ctx.chatId} sender allowlist`);
+        return;
+      }
     }
 
     const { requireMention } = resolveFeishuReplyPolicy({


### PR DESCRIPTION
## Problem

The `groupAllowFrom` config is intended to specify which **groups** (by group ID like `oc_xxx`) the bot should respond in. However, the current code incorrectly checks the **sender ID** (`ou_xxx`) against this list.

Since user IDs (`ou_xxx`) never match group IDs (`oc_xxx`), the allowlist check always fails when `groupPolicy: "allowlist"` is set.

## Solution

Separate two concepts:
1. **Group-level allowlist** (`groupAllowFrom`): Which groups the bot responds in
2. **Sender-level allowlist** (`groupConfig.allowFrom`): Which senders within a specific group are allowed

The fix:
1. First checks if `ctx.chatId` (group ID) is in the `groupAllowFrom` list
2. Then optionally checks sender-level allowlist via `groupConfig.allowFrom`

## Example Config

```json
{
  "channels": {
    "feishu": {
      "groupPolicy": "allowlist",
      "groupAllowFrom": ["oc_xxx", "oc_yyy"],  // Groups where bot responds
      "groups": {
        "oc_xxx": {
          "allowFrom": ["ou_user1", "ou_user2"]  // Senders allowed in this group
        }
      }
    }
  }
}
```

## Changes

- `src/bot.ts`: Fixed group allowlist check logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)