### PR TITLE
feat: add chat history fetching for summary requests

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -48,3 +48,20 @@ export type FeishuMediaInfo = {
   contentType?: string;
   placeholder: string;
 };
+
+export type FeishuHistoryMessage = {
+  messageId: string;
+  senderId: string;
+  senderType: string;
+  content: string;
+  contentType: string;
+  createTime: number;
+  deleted?: boolean;
+};
+
+export type ListMessagesResult = {
+  messages: FeishuHistoryMessage[];
+  hasMore: boolean;
+  pageToken?: string;
+  total: number;
+};


### PR DESCRIPTION
## Summary

Enable users to request chat history summarization by adding automatic chat history fetching and context injection.

## Features

### New Functions

**`listMessagesFeishu()`** - Fetch chat history with pagination
- Auto-paginates to fetch requested count (API limit is 50/page)
- Supports time range filtering and sort order
- Handles various message types (text, image, file, audio, video, etc.)

**`isHistoryRequest()`** - Detect history/summary requests
- Matches Chinese patterns: 聊天记录, 历史消息, 总结聊天
- Matches English patterns: chat history, message history, summarize chat

**`fetchChatHistoryForAgent()`** - Format history for agent context
- Extracts requested count from message (e.g., "最近100条")
- Formats messages with timestamps for agent consumption

### Integration

When a user in a group chat sends a message like:
- "总结一下最近50条聊天记录"
- "帮我看看历史消息"
- "summarize the chat history"

The bot automatically:
1. Detects the history request
2. Fetches the requested number of messages
3. Formats them chronologically
4. Injects the history into the agent's context
5. Agent can then summarize or analyze the chat

## Example Usage

User: `@bot 帮我总结一下最近100条消息`

Agent receives context with:
```
--- 群聊历史记录 (最近 100 条消息) ---
[01/30 14:30] user1: 明天开会
[01/30 14:31] user2: 好的，几点？
[01/30 14:32] user1: 下午3点
...
--- 历史记录结束 ---

user1: @bot 帮我总结一下最近100条消息
```

## Changes

| File | Description |
|------|-------------|
| `src/types.ts` | Added `FeishuHistoryMessage` and `ListMessagesResult` types |
| `src/send.ts` | Added `listMessagesFeishu()` function |
| `src/bot.ts` | Added history request detection and context injection |

🤖 Generated with [Claude Code](https://claude.com/claude-code)