### PR TITLE
feat: notify user on Feishu API permission errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ channels:
 - User and group directory lookup
 - **Card render mode**: Optional markdown rendering with syntax highlighting
 - **@mention forwarding**: When you @mention someone in your message, the bot's reply will automatically @mention them too
+- **Permission error notification**: When the bot encounters a Feishu API permission error, it automatically notifies the user with the permission grant URL
 
 #### @Mention Forwarding
 
@@ -280,6 +281,7 @@ channels:
 - 用户和群组目录查询
 - **卡片渲染模式**：支持语法高亮的 Markdown 渲染
 - **@ 转发功能**：在消息中 @ 某人，机器人的回复会自动 @ 该用户
+- **权限错误提示**：当机器人遇到飞书 API 权限错误时，会自动通知用户并提供权限授权链接
 
 #### @ 转发功能
 


### PR DESCRIPTION
## Summary

- When the bot encounters a Feishu API permission error (e.g., missing contact directory permissions), it now automatically notifies the user
- The notification includes the permission grant URL for admin to authorize
- Uses a 5-minute cooldown to avoid spamming repeated notifications
- The notification is generated by the agent, so it adapts to the user's language naturally

## Changes

- `src/bot.ts`: Add permission error detection, extraction, and agent notification dispatch
- `README.md`: Document the new feature in both English and Chinese

## Test plan

- [ ] Trigger a permission error (e.g., by not granting contact permissions)
- [ ] Verify the bot sends a notification with the grant URL
- [ ] Verify the bot still responds to the user's actual message
- [ ] Verify the cooldown prevents repeated notifications within 5 minutes

🤖 Generated with [Claude Code](https://claude.ai/code)