### PR TITLE
feat: support private Feishu deployment URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ channels:
     enabled: true
     appId: "cli_xxxxx"
     appSecret: "secret"
-    # Domain: "feishu" (China) or "lark" (International)
-    domain: "feishu"
+    # Domain: "feishu" (China), "lark" (International), or custom URL
+    domain: "feishu"  # or "https://open.xxx.cn" for private deployment
     # Connection mode: "websocket" (recommended) or "webhook"
     connectionMode: "websocket"
     # Webhook path (default: "/feishu/events")
@@ -367,8 +367,8 @@ channels:
     enabled: true
     appId: "cli_xxxxx"
     appSecret: "secret"
-    # 域名: "feishu" (国内) 或 "lark" (国际)
-    domain: "feishu"
+    # 域名: "feishu" (国内)、"lark" (国际) 或自定义 URL
+    domain: "feishu"  # 私有化部署可用 "https://open.xxx.cn"
     # 连接模式: "websocket" (推荐) 或 "webhook"
     connectionMode: "websocket"
     # Webhook 路径 (默认: "/feishu/events")

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -51,7 +51,7 @@ function extractPermissionError(err: unknown): PermissionError | null {
 
   // Extract the grant URL from the error message (contains the direct link)
   const msg = feishuErr.msg ?? "";
-  const urlMatch = msg.match(/https:\/\/open\.feishu\.cn\/app\/[^\s,]+/);
+  const urlMatch = msg.match(/https:\/\/[^\s,]+\/app\/[^\s,]+/);
   const grantUrl = urlMatch?.[0];
 
   return {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -71,7 +71,12 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         appSecret: { type: "string" },
         encryptKey: { type: "string" },
         verificationToken: { type: "string" },
-        domain: { type: "string", enum: ["feishu", "lark"] },
+        domain: {
+          oneOf: [
+            { type: "string", enum: ["feishu", "lark"] },
+            { type: "string", format: "uri", pattern: "^https://" },
+          ],
+        },
         connectionMode: { type: "string", enum: ["websocket", "webhook"] },
         webhookPath: { type: "string" },
         webhookPort: { type: "integer", minimum: 1 },

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,8 +5,10 @@ import { resolveFeishuCredentials } from "./accounts.js";
 let cachedClient: Lark.Client | null = null;
 let cachedConfig: { appId: string; appSecret: string; domain: FeishuDomain } | null = null;
 
-function resolveDomain(domain: FeishuDomain) {
-  return domain === "lark" ? Lark.Domain.Lark : Lark.Domain.Feishu;
+function resolveDomain(domain: FeishuDomain): Lark.Domain | string {
+  if (domain === "lark") return Lark.Domain.Lark;
+  if (domain === "feishu") return Lark.Domain.Feishu;
+  return domain.replace(/\/+$/, ""); // Custom URL, remove trailing slashes
 }
 
 export function createFeishuClient(cfg: FeishuConfig): Lark.Client {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -3,7 +3,10 @@ export { z };
 
 const DmPolicySchema = z.enum(["open", "pairing", "allowlist"]);
 const GroupPolicySchema = z.enum(["open", "allowlist", "disabled"]);
-const FeishuDomainSchema = z.enum(["feishu", "lark"]);
+const FeishuDomainSchema = z.union([
+  z.enum(["feishu", "lark"]),
+  z.string().url().startsWith("https://"),
+]);
 const FeishuConnectionModeSchema = z.enum(["websocket", "webhook"]);
 
 const ToolPolicySchema = z

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import type { MentionTarget } from "./mention.js";
 export type FeishuConfig = z.infer<typeof FeishuConfigSchema>;
 export type FeishuGroupConfig = z.infer<typeof FeishuGroupSchema>;
 
-export type FeishuDomain = "feishu" | "lark";
+export type FeishuDomain = "feishu" | "lark" | (string & {});
 export type FeishuConnectionMode = "websocket" | "webhook";
 
 export type ResolvedFeishuAccount = {


### PR DESCRIPTION
## Summary
- Add support for custom domain URLs (e.g., `https://open.xxx.cn`) for private Feishu deployments
- Extend `domain` config to accept HTTPS URLs in addition to `"feishu"` and `"lark"` presets
- Update permission URL regex to match any HTTPS domain (not just `open.feishu.cn`)

## Configuration Example
```yaml
channels:
  feishu:
    appId: "cli_xxx"
    appSecret: "xxx"
    domain: "https://open.xxx.cn"  # Private deployment
```

## Test plan
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Verify `"feishu"` and `"lark"` presets still work
- [ ] Test with a custom URL to confirm SDK client is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)