### PR TITLE
fix: 修复文件上传时凭证类型不匹配问题

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -201,12 +201,9 @@ export async function uploadImageFeishu(params: {
   accountId?: string;
 }): Promise<UploadImageResult> {
   const { cfg, image, imageType = "message", accountId } = params;
-  const account = resolveFeishuAccount({ cfg, accountId });
-  if (!account.configured) {
-    throw new Error(`Feishu account "${account.accountId}" not configured`);
-  }
+  const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
 
-  const client = createFeishuClient(account);
+  const client = createFeishuClient(feishuCfg);
 
   // SDK expects a Readable stream, not a Buffer
   // Use type assertion since SDK actually accepts any Readable at runtime
@@ -248,12 +245,9 @@ export async function uploadFileFeishu(params: {
   accountId?: string;
 }): Promise<UploadFileResult> {
   const { cfg, file, fileName, fileType, duration, accountId } = params;
-  const account = resolveFeishuAccount({ cfg, accountId });
-  if (!account.configured) {
-    throw new Error(`Feishu account "${account.accountId}" not configured`);
-  }
+  const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
 
-  const client = createFeishuClient(account);
+  const client = createFeishuClient(feishuCfg);
 
   // SDK expects a Readable stream, not a Buffer
   // Use type assertion since SDK actually accepts any Readable at runtime
@@ -294,12 +288,9 @@ export async function sendImageFeishu(params: {
   accountId?: string;
 }): Promise<SendMediaResult> {
   const { cfg, to, imageKey, replyToMessageId, accountId } = params;
-  const account = resolveFeishuAccount({ cfg, accountId });
-  if (!account.configured) {
-    throw new Error(`Feishu account "${account.accountId}" not configured`);
-  }
+  const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
 
-  const client = createFeishuClient(account);
+  const client = createFeishuClient(feishuCfg);
   const receiveId = normalizeFeishuTarget(to);
   if (!receiveId) {
     throw new Error(`Invalid Feishu target: ${to}`);
@@ -357,12 +348,9 @@ export async function sendFileFeishu(params: {
   accountId?: string;
 }): Promise<SendMediaResult> {
   const { cfg, to, fileKey, replyToMessageId, accountId } = params;
-  const account = resolveFeishuAccount({ cfg, accountId });
-  if (!account.configured) {
-    throw new Error(`Feishu account "${account.accountId}" not configured`);
-  }
+  const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
 
-  const client = createFeishuClient(account);
+  const client = createFeishuClient(feishuCfg);
   const receiveId = normalizeFeishuTarget(to);
   if (!receiveId) {
     throw new Error(`Invalid Feishu target: ${to}`);


### PR DESCRIPTION
## 问题

PR #137 (multi-account support) 引入的bug：

- media.ts中的函数通过resolveFeishuAccount获取凭证

- 但createFeishuClient期望FeishuConfig类型

- 类型不匹配导致凭证解析失败，文件上传报错



## 修复

直接传入cfg.channels?.feishu给createFeishuClient，绕过resolveFeishuAccount中转。



## 改动

- uploadImageFeishu

- uploadFileFeishu

- sendImageFeishu

- sendFileFeishu

- 减少代码12行（8 insertions, 20 deletions）



## 测试

✅ MP3音频文件上传

✅ MD文本文件上传

✅ tar.gz压缩包上传



## 关联

Closes #184

