### PR TITLE
Add @mention syntax sugar for improved developer experience

### DIFF
--- a/MENTION_SYNTAX_SUGAR.md
+++ b/MENTION_SYNTAX_SUGAR.md
@@ -1,0 +1,73 @@
+# Mention Syntax Sugar Feature
+
+This PR adds a convenient syntax sugar for @mentions in Feishu messages.
+
+## Problem
+Previously, to mention users in Feishu messages, you had to construct the full HTML-like tags manually:
+```html
+<at user_id="ou_abc123">Username</at>
+```
+
+This is verbose and error-prone for developers.
+
+## Solution
+This PR introduces a simple syntax sugar that automatically parses `@user_id:name` format:
+
+### Examples
+```javascript
+// Old way (still supported)
+await sendMessage({ 
+  text: '<at user_id="ou_mockuser123456789abcdef">Alice</at> Hello!',
+  // ... 
+});
+
+// New way with syntax sugar ✨
+await sendMessage({ 
+  text: '@ou_mockuser123456789abcdef:Alice Hello!',
+  // ... 
+});
+
+// Even shorter - name is optional
+await sendMessage({ 
+  text: '@ou_mockuser123456789abcdef Hello!',  // Will display the user ID
+  // ... 
+});
+```
+
+### Supported Formats
+- `@ou_mockuser123456789abcdef:Alice` - Mention human users
+- `@cli_mockbot987654321fedcba:BotAssistant` - Mention bots/apps
+- `@ou_mockuser123456789abcdef` - Mention without display name (shows ID)
+
+## Implementation Details
+
+### 1. Added `parseMentionsFromText()` function
+- Parses `@user_id:name` patterns using regex
+- Extracts user ID and display name
+- Automatically handles both human users (`ou_*`) and bots (`cli_*`)
+
+### 2. Enhanced `formatMentionForText()` function  
+- Automatically uses correct format for different target types:
+  - Human users: `<at user_id="ou_*">name</at>`
+  - Bots: `<at id="cli_*">name</at>`
+
+### 3. Updated outbound adapter
+- Automatically processes syntax sugar before sending
+- Maintains backward compatibility with existing code
+- Works with both `sendText` and `sendMedia` functions
+
+## Benefits
+- **Simpler syntax**: `@ou_mockuser123:Alice` vs `<at user_id="ou_mockuser123">Alice</at>`
+- **Auto-detection**: Automatically handles human/bot mention formats
+- **Backward compatible**: Existing code continues to work
+- **Developer friendly**: More intuitive for developers coming from other platforms
+
+## Testing
+- Tested with human user mentions (`ou_mockuser*`)
+- Tested with bot mentions (`cli_mockbot*`) 
+- Verified backward compatibility
+- Tested mixed mentions in single message
+
+---
+
+This enhancement makes the Feishu plugin more developer-friendly while maintaining full compatibility with existing implementations.

--- a/src/mention.ts
+++ b/src/mention.ts
@@ -76,6 +76,11 @@ export function extractMessageBody(text: string, allMentionKeys: string[]): stri
  * Format @mention for text message
  */
 export function formatMentionForText(target: MentionTarget): string {
+  // 机器人使用不同的格式
+  if (target.openId.startsWith('cli_')) {
+    return `<at id="${target.openId}">${target.name}</at>`;
+  }
+  // 人类用户使用标准格式
   return `<at user_id="${target.openId}">${target.name}</at>`;
 }
 

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -2,6 +2,30 @@ import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu } from "./send.js";
 import { sendMediaFeishu } from "./media.js";
+import type { MentionTarget } from "./mention.js";
+
+// 解析@语法的辅助函数
+function parseMentionsFromText(text: string): { mentions: MentionTarget[]; cleanText: string } {
+  const mentions: MentionTarget[] = [];
+  let cleanText = text;
+  
+  // 匹配 @user_id:name 或 @app_id:name 格式
+  const mentionRegex = /@((?:ou_|cli_)[a-zA-Z0-9_-]+)(?::([^@\s]+))?/g;
+  let match;
+  
+  while ((match = mentionRegex.exec(text)) !== null) {
+    const [fullMatch, id, name] = match;
+    mentions.push({
+      openId: id,
+      name: name || id, // 如果没有提供名字，使用ID
+      key: fullMatch, // 原始匹配的文本作为key
+    });
+    // 从文本中移除@语法，替换为普通文本
+    cleanText = cleanText.replace(fullMatch, name || id);
+  }
+  
+  return { mentions, cleanText };
+}
 
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
@@ -9,13 +33,31 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   sendText: async ({ cfg, to, text, accountId }) => {
-    const result = await sendMessageFeishu({ cfg, to, text, accountId });
+    // 解析@语法
+    const { mentions, cleanText } = parseMentionsFromText(text);
+    
+    // 发送消息，包含@功能
+    const result = await sendMessageFeishu({ 
+      cfg, 
+      to, 
+      text: cleanText,
+      mentions: mentions.length > 0 ? mentions : undefined,
+      accountId 
+    });
     return { channel: "feishu", ...result };
   },
   sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
     // Send text first if provided
     if (text?.trim()) {
-      await sendMessageFeishu({ cfg, to, text, accountId });
+      // 解析@语法
+      const { mentions, cleanText } = parseMentionsFromText(text);
+      await sendMessageFeishu({ 
+        cfg, 
+        to, 
+        text: cleanText,
+        mentions: mentions.length > 0 ? mentions : undefined,
+        accountId
+      });
     }
 
     // Upload and send media if URL provided
@@ -34,7 +76,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     }
 
     // No media URL, just return text result
-    const result = await sendMessageFeishu({ cfg, to, text: text ?? "", accountId });
+    const { mentions, cleanText } = parseMentionsFromText(text ?? "");
+    const result = await sendMessageFeishu({ 
+      cfg, 
+      to, 
+      text: cleanText,
+      mentions: mentions.length > 0 ? mentions : undefined,
+      accountId
+    });
     return { channel: "feishu", ...result };
   },
 };


### PR DESCRIPTION
# Mention Syntax Sugar Feature

This PR adds a convenient syntax sugar for @mentions in Feishu messages.

## Problem
Previously, to mention users in Feishu messages, you had to construct the full HTML-like tags manually:
```html
<at user_id="ou_abc123">Username</at>
```

This is verbose and error-prone for developers.

## Solution
This PR introduces a simple syntax sugar that automatically parses `@user_id:name` format:

### Examples
```javascript
// Old way (still supported)
await sendMessage({ 
  text: '<at user_id="ou_mockuser123456789abcdef">Alice</at> Hello!',
  // ... 
});

// New way with syntax sugar ✨
await sendMessage({ 
  text: '@ou_mockuser123456789abcdef:Alice Hello!',
  // ... 
});

// Even shorter - name is optional
await sendMessage({ 
  text: '@ou_mockuser123456789abcdef Hello!',  // Will display the user ID
  // ... 
});
```

### Supported Formats
- `@ou_mockuser123456789abcdef:Alice` - Mention human users
- `@cli_mockbot987654321fedcba:BotAssistant` - Mention bots/apps
- `@ou_mockuser123456789abcdef` - Mention without display name (shows ID)

## Implementation Details

### 1. Added `parseMentionsFromText()` function
- Parses `@user_id:name` patterns using regex
- Extracts user ID and display name
- Automatically handles both human users (`ou_*`) and bots (`cli_*`)

### 2. Enhanced `formatMentionForText()` function  
- Automatically uses correct format for different target types:
  - Human users: `<at user_id="ou_*">name</at>`
  - Bots: `<at id="cli_*">name</at>`

### 3. Updated outbound adapter
- Automatically processes syntax sugar before sending
- Maintains backward compatibility with existing code
- Works with both `sendText` and `sendMedia` functions

## Benefits
- **Simpler syntax**: `@ou_mockuser123:Alice` vs `<at user_id="ou_mockuser123">Alice</at>`
- **Auto-detection**: Automatically handles human/bot mention formats
- **Backward compatible**: Existing code continues to work
- **Developer friendly**: More intuitive for developers coming from other platforms

## Testing
- Tested with human user mentions (`ou_mockuser*`)
- Tested with bot mentions (`cli_mockbot*`) 
- Verified backward compatibility
- Tested mixed mentions in single message

---

This enhancement makes the Feishu plugin more developer-friendly while maintaining full compatibility with existing implementations.