### PR TITLE
feat(feishu): add task v2 tools and shared api helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ openclaw plugins update feishu
 | `drive:drive:readonly` | `feishu_drive` | List folders, get file info |
 | `wiki:wiki:readonly` | `feishu_wiki` | List spaces, list nodes, get node info, search |
 | `bitable:app:readonly` | `feishu_bitable` | Read bitable records and fields |
+| `task:task:read` | `feishu_task_get` | Get task details |
 
 **Read-write** (optional, for create/edit/delete operations):
 
@@ -73,6 +74,9 @@ openclaw plugins update feishu
 | `drive:drive` | `feishu_doc`, `feishu_drive` | Upload images to documents, create folders, move/delete files |
 | `wiki:wiki` | `feishu_wiki` | Create/move/rename wiki nodes |
 | `bitable:app` | `feishu_bitable` | Create/update/delete bitable records and manage fields |
+| `task:task:write` | `feishu_task_create`, `feishu_task_update`, `feishu_task_delete` | Create/update/delete tasks |
+
+> Task scope names may vary slightly in Feishu console UI. If needed, search for Task-related permissions and grant read/write accordingly.
 
 #### Drive Access ⚠️
 
@@ -263,6 +267,7 @@ session:
 - **Wiki tools**: Navigate knowledge bases, list spaces, get node details, search, create/move/rename nodes
 - **Drive tools**: List folders, get file info, create folders, move/delete files
 - **Bitable tools**: Manage bitable (多维表格) fields and records (read/create/update/delete), supports both `/base/` and `/wiki/` URLs
+- **Task tools**: Create, get details, update, and delete tasks via Feishu Task v2 API
 - **@mention forwarding**: When you @mention someone in your message, the bot's reply will automatically @mention them too
 - **Permission error notification**: When the bot encounters a Feishu API permission error, it automatically notifies the user with the permission grant URL
 - **Dynamic agent creation**: Each DM user can have their own isolated agent instance with dedicated workspace (optional)
@@ -374,6 +379,7 @@ openclaw plugins update feishu
 | `drive:drive:readonly` | `feishu_drive` | 列出文件夹、获取文件信息 |
 | `wiki:wiki:readonly` | `feishu_wiki` | 列出空间、列出节点、获取节点详情、搜索 |
 | `bitable:app:readonly` | `feishu_bitable` | 读取多维表格记录和字段 |
+| `task:task:read` | `feishu_task_get` | 获取任务详情 |
 
 **读写权限**（可选，用于创建/编辑/删除操作）：
 
@@ -384,6 +390,9 @@ openclaw plugins update feishu
 | `drive:drive` | `feishu_doc`, `feishu_drive` | 上传图片到文档、创建文件夹、移动/删除文件 |
 | `wiki:wiki` | `feishu_wiki` | 创建/移动/重命名知识库节点 |
 | `bitable:app` | `feishu_bitable` | 创建/更新/删除多维表格记录并管理字段 |
+| `task:task:write` | `feishu_task_create`, `feishu_task_update`, `feishu_task_delete` | 创建/更新/删除任务 |
+
+> 飞书控制台中任务权限的显示名称可能略有差异，必要时可按关键字 `task` 搜索并授予对应读写权限。
 
 #### 云空间访问权限 ⚠️
 
@@ -574,6 +583,7 @@ session:
 - **知识库工具**：浏览知识库、列出空间、获取节点详情、搜索、创建/移动/重命名节点
 - **云空间工具**：列出文件夹、获取文件信息、创建文件夹、移动/删除文件
 - **多维表格工具**：支持多维表格字段与记录的读取/创建/更新/删除，支持 `/base/` 和 `/wiki/` 两种链接格式
+- **任务工具**：基于 Task v2 API 支持任务创建、获取详情、更新和删除
 - **@ 转发功能**：在消息中 @ 某人，机器人的回复会自动 @ 该用户
 - **权限错误提示**：当机器人遇到飞书 API 权限错误时，会自动通知用户并提供权限授权链接
 - **动态 Agent 创建**：每个私聊用户可拥有独立的 agent 实例和专属 workspace（可选）

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuWikiTools } from "./src/wiki.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { registerFeishuBitableTools } from "./src/bitable.js";
+import { registerFeishuTaskTools } from "./src/task.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
 export {
@@ -57,6 +58,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuTaskTools(api);
   },
 };
 

--- a/src/bitable-tools/common.ts
+++ b/src/bitable-tools/common.ts
@@ -1,4 +1,10 @@
 import { createFeishuClient } from "../client.js";
+import {
+  errorResult,
+  json,
+  runFeishuApiCall,
+  type FeishuApiResponse,
+} from "../tools-common/feishu-api.js";
 
 export type BitableClient = ReturnType<typeof createFeishuClient>;
 
@@ -14,29 +20,7 @@ export type BitableFieldCreateData = AppTableFieldCreatePayload["data"];
 export type BitableFieldUpdateData = AppTableFieldUpdatePayload["data"];
 export type BitableFieldDescription = NonNullable<BitableFieldCreateData["description"]>;
 
-export function json(data: unknown) {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
-    details: data,
-  };
-}
-
-export function errorResult(err: unknown) {
-  return json({ error: err instanceof Error ? err.message : String(err) });
-}
-
-type FeishuApiResponse = {
-  code?: number;
-  msg?: string;
-  log_id?: string;
-  logId?: string;
-};
-
-type FeishuErrorInfo = {
-  code?: number;
-  msg?: string;
-  logId?: string;
-};
+export { json, errorResult };
 
 const RETRYABLE_BITABLE_ERROR_CODES = new Set<number>([
   1254607, // Data not ready
@@ -47,125 +31,16 @@ const RETRYABLE_BITABLE_ERROR_CODES = new Set<number>([
 
 const RETRY_BACKOFF_MS = [350, 900, 1800];
 
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function extractFeishuErrorInfo(err: unknown): FeishuErrorInfo | null {
-  if (!err) return null;
-
-  // Feishu SDK may throw nested array structures like:
-  // [axiosError, { code, msg, log_id, ... }]
-  if (Array.isArray(err)) {
-    for (let i = err.length - 1; i >= 0; i -= 1) {
-      const info = extractFeishuErrorInfo(err[i]);
-      if (info) return info;
-    }
-    return null;
-  }
-
-  if (typeof err !== "object") return null;
-
-  const obj = err as Record<string, unknown>;
-  const codeValue = obj.code;
-  const msgValue = obj.msg ?? obj.message;
-  const logIdValue = obj.log_id ?? obj.logId;
-
-  const hasCode = typeof codeValue === "number";
-  const hasMsg = typeof msgValue === "string";
-  const hasLogId = typeof logIdValue === "string";
-
-  if (hasCode || hasMsg || hasLogId) {
-    return {
-      code: hasCode ? codeValue : undefined,
-      msg: hasMsg ? (msgValue as string) : undefined,
-      logId: hasLogId ? (logIdValue as string) : undefined,
-    };
-  }
-
-  const responseData = (obj.response as { data?: unknown } | undefined)?.data;
-  if (responseData) return extractFeishuErrorInfo(responseData);
-
-  return null;
-}
-
-function toError(err: unknown, context: string): Error {
-  if (err instanceof Error) {
-    const info = extractFeishuErrorInfo(err);
-    if (!info) return err;
-    const details = [
-      info.msg || `code ${info.code}`,
-      info.code !== undefined ? `code=${info.code}` : undefined,
-      info.logId ? `log_id=${info.logId}` : undefined,
-    ]
-      .filter(Boolean)
-      .join(", ");
-    return new Error(`${context} failed: ${details}`);
-  }
-
-  const info = extractFeishuErrorInfo(err);
-  if (info) {
-    const details = [
-      info.msg || `code ${info.code}`,
-      info.code !== undefined ? `code=${info.code}` : undefined,
-      info.logId ? `log_id=${info.logId}` : undefined,
-    ]
-      .filter(Boolean)
-      .join(", ");
-    return new Error(`${context} failed: ${details}`);
-  }
-
-  return new Error(`${context} failed: ${String(err)}`);
-}
-
-function assertFeishuOk<T extends FeishuApiResponse>(response: T, context: string): T {
-  if (response.code === undefined || response.code === 0) return response;
-
-  const message = response.msg || `code ${response.code}`;
-  const detail = response.log_id ?? response.logId;
-  const error = new Error(
-    detail
-      ? `${context} failed: ${message}, code=${response.code}, log_id=${detail}`
-      : `${context} failed: ${message}, code=${response.code}`,
-  ) as Error & { code?: number; log_id?: string; logId?: string };
-  error.code = response.code;
-  if (detail) {
-    error.log_id = detail;
-    error.logId = detail;
-  }
-  throw error;
-}
-
 export async function runBitableApiCall<T extends FeishuApiResponse>(
   context: string,
   fn: () => Promise<T>,
 ): Promise<T> {
   // Bitable APIs can briefly return "Data not ready" after writes.
   // Retry only known transient codes with short backoff.
-  const maxAttempts = RETRY_BACKOFF_MS.length + 1;
-  let attempt = 0;
-  let lastErr: unknown = null;
-
-  while (attempt < maxAttempts) {
-    try {
-      const response = await fn();
-      return assertFeishuOk(response, context);
-    } catch (err) {
-      lastErr = err;
-      const info = extractFeishuErrorInfo(err);
-      const retryable = info?.code !== undefined && RETRYABLE_BITABLE_ERROR_CODES.has(info.code);
-      const exhausted = attempt >= maxAttempts - 1;
-      if (!retryable || exhausted) {
-        throw toError(err, context);
-      }
-
-      const backoffMs = RETRY_BACKOFF_MS[Math.min(attempt, RETRY_BACKOFF_MS.length - 1)];
-      await sleep(backoffMs);
-      attempt += 1;
-    }
-  }
-
-  throw toError(lastErr, context);
+  return runFeishuApiCall(context, fn, {
+    retryableCodes: RETRYABLE_BITABLE_ERROR_CODES,
+    backoffMs: RETRY_BACKOFF_MS,
+  });
 }
 
 const FIELD_TYPE_NAMES: Record<number, string> = {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -74,6 +74,7 @@ const DynamicAgentCreationSchema = z
  * Dependencies:
  * - wiki requires doc (wiki content is edited via doc tools)
  * - perm can work independently but is typically used with drive
+ * - task can work independently
  */
 const FeishuToolsConfigSchema = z
   .object({
@@ -82,6 +83,7 @@ const FeishuToolsConfigSchema = z
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
+    task: z.boolean().optional(), // Task operations (default: true)
   })
   .strict()
   .optional();

--- a/src/task-tools/actions.ts
+++ b/src/task-tools/actions.ts
@@ -1,0 +1,137 @@
+import type { TaskClient } from "./common.js";
+import type {
+  CreateTaskParams,
+  GetTaskParams,
+  TaskUpdateTask,
+  UpdateTaskParams,
+} from "./schemas.js";
+import { runTaskApiCall } from "./common.js";
+
+const SUPPORTED_PATCH_FIELDS = new Set<keyof TaskUpdateTask>([
+  "summary",
+  "description",
+  "due",
+  "start",
+  "extra",
+  "completed_at",
+  "repeat_rule",
+  "mode",
+  "is_milestone",
+]);
+
+function omitUndefined<T extends Record<string, unknown>>(obj: T): T {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => value !== undefined),
+  ) as T;
+}
+
+function inferUpdateFields(task: TaskUpdateTask): string[] {
+  return Object.keys(task).filter((field) =>
+    SUPPORTED_PATCH_FIELDS.has(field as keyof TaskUpdateTask),
+  );
+}
+
+function formatTask(task: Record<string, unknown> | undefined) {
+  if (!task) return undefined;
+  return {
+    guid: task.guid,
+    task_id: task.task_id,
+    summary: task.summary,
+    description: task.description,
+    status: task.status,
+    url: task.url,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+    completed_at: task.completed_at,
+    due: task.due,
+    start: task.start,
+    is_milestone: task.is_milestone,
+    members: task.members,
+    tasklists: task.tasklists,
+  };
+}
+
+export async function createTask(client: TaskClient, params: CreateTaskParams) {
+  const res = await runTaskApiCall("task.v2.task.create", () =>
+    client.task.v2.task.create({
+      data: omitUndefined({
+        summary: params.summary,
+        description: params.description,
+        due: params.due,
+        start: params.start,
+        extra: params.extra,
+        completed_at: params.completed_at,
+        members: params.members,
+        repeat_rule: params.repeat_rule,
+        tasklists: params.tasklists,
+        mode: params.mode,
+        is_milestone: params.is_milestone,
+      }),
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function deleteTask(client: TaskClient, taskGuid: string) {
+  await runTaskApiCall("task.v2.task.delete", () =>
+    client.task.v2.task.delete({
+      path: { task_guid: taskGuid },
+    }),
+  );
+
+  return {
+    success: true,
+    task_guid: taskGuid,
+  };
+}
+
+export async function getTask(client: TaskClient, params: GetTaskParams) {
+  const res = await runTaskApiCall("task.v2.task.get", () =>
+    client.task.v2.task.get({
+      path: { task_guid: params.task_guid },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function updateTask(client: TaskClient, params: UpdateTaskParams) {
+  const task = omitUndefined(params.task as Record<string, unknown>) as TaskUpdateTask;
+  const updateFields = params.update_fields?.length ? params.update_fields : inferUpdateFields(task);
+
+  if (Object.keys(task).length === 0) {
+    throw new Error("task update payload is empty");
+  }
+  if (updateFields.length === 0) {
+    throw new Error("no valid update_fields provided or inferred from task payload");
+  }
+
+  const res = await runTaskApiCall("task.v2.task.patch", () =>
+    client.task.v2.task.patch({
+      path: { task_guid: params.task_guid },
+      data: {
+        task,
+        update_fields: updateFields,
+      },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+    update_fields: updateFields,
+  };
+}

--- a/src/task-tools/common.ts
+++ b/src/task-tools/common.ts
@@ -1,0 +1,18 @@
+import { createFeishuClient } from "../client.js";
+import {
+  errorResult,
+  json,
+  runFeishuApiCall,
+  type FeishuApiResponse,
+} from "../tools-common/feishu-api.js";
+
+export type TaskClient = ReturnType<typeof createFeishuClient>;
+
+export { json, errorResult };
+
+export async function runTaskApiCall<T extends FeishuApiResponse>(
+  context: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return runFeishuApiCall(context, fn);
+}

--- a/src/task-tools/register.ts
+++ b/src/task-tools/register.ts
@@ -1,0 +1,104 @@
+import type { TSchema } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { listEnabledFeishuAccounts } from "../accounts.js";
+import { createFeishuClient } from "../client.js";
+import { resolveToolsConfig } from "../tools-config.js";
+import { createTask, deleteTask, getTask, updateTask } from "./actions.js";
+import { errorResult, json, type TaskClient } from "./common.js";
+import {
+  CreateTaskSchema,
+  type CreateTaskParams,
+  DeleteTaskSchema,
+  type DeleteTaskParams,
+  GetTaskSchema,
+  type GetTaskParams,
+  UpdateTaskSchema,
+  type UpdateTaskParams,
+} from "./schemas.js";
+
+type ToolSpec<P> = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: TSchema;
+  run: (client: TaskClient, params: P) => Promise<unknown>;
+};
+
+function registerTaskTool<P>(
+  api: OpenClawPluginApi,
+  getClient: () => TaskClient,
+  spec: ToolSpec<P>,
+) {
+  api.registerTool(
+    {
+      name: spec.name,
+      label: spec.label,
+      description: spec.description,
+      parameters: spec.parameters,
+      async execute(_toolCallId, params) {
+        try {
+          return json(await spec.run(getClient(), params as P));
+        } catch (err) {
+          return errorResult(err);
+        }
+      },
+    },
+    { name: spec.name },
+  );
+}
+
+export function registerFeishuTaskTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_task: No config available, skipping task tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_task: No Feishu accounts configured, skipping task tools");
+    return;
+  }
+
+  const firstAccount = accounts[0];
+  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  if (!toolsCfg.task) {
+    api.logger.debug?.("feishu_task: task tools disabled in config");
+    return;
+  }
+
+  const getClient = () => createFeishuClient(firstAccount);
+
+  registerTaskTool<CreateTaskParams>(api, getClient, {
+    name: "feishu_task_create",
+    label: "Feishu Task Create",
+    description: "Create a Feishu task (task v2)",
+    parameters: CreateTaskSchema,
+    run: (client, params) => createTask(client, params),
+  });
+
+  registerTaskTool<DeleteTaskParams>(api, getClient, {
+    name: "feishu_task_delete",
+    label: "Feishu Task Delete",
+    description: "Delete a Feishu task by task_guid (task v2)",
+    parameters: DeleteTaskSchema,
+    run: (client, { task_guid }) => deleteTask(client, task_guid),
+  });
+
+  registerTaskTool<GetTaskParams>(api, getClient, {
+    name: "feishu_task_get",
+    label: "Feishu Task Get",
+    description: "Get Feishu task details by task_guid (task v2)",
+    parameters: GetTaskSchema,
+    run: (client, params) => getTask(client, params),
+  });
+
+  registerTaskTool<UpdateTaskParams>(api, getClient, {
+    name: "feishu_task_update",
+    label: "Feishu Task Update",
+    description: "Update a Feishu task by task_guid (task v2 patch)",
+    parameters: UpdateTaskSchema,
+    run: (client, params) => updateTask(client, params),
+  });
+
+  api.logger.info?.("feishu_task: Registered 4 task tools");
+}

--- a/src/task-tools/schemas.ts
+++ b/src/task-tools/schemas.ts
@@ -1,0 +1,138 @@
+import { Type } from "@sinclair/typebox";
+import type { TaskClient } from "./common.js";
+
+type TaskCreatePayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["create"]>[0]>;
+type TaskUpdatePayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["patch"]>[0]>;
+type TaskDeletePayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["delete"]>[0]>;
+type TaskGetPayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["get"]>[0]>;
+
+export type TaskCreateData = TaskCreatePayload["data"];
+export type TaskUpdateData = TaskUpdatePayload["data"];
+export type TaskUpdateTask = NonNullable<TaskUpdateData["task"]>;
+
+export type CreateTaskParams = {
+  summary: TaskCreateData["summary"];
+  description?: TaskCreateData["description"];
+  due?: TaskCreateData["due"];
+  start?: TaskCreateData["start"];
+  extra?: TaskCreateData["extra"];
+  completed_at?: TaskCreateData["completed_at"];
+  members?: TaskCreateData["members"];
+  repeat_rule?: TaskCreateData["repeat_rule"];
+  tasklists?: TaskCreateData["tasklists"];
+  mode?: TaskCreateData["mode"];
+  is_milestone?: TaskCreateData["is_milestone"];
+  user_id_type?: NonNullable<TaskCreatePayload["params"]>["user_id_type"];
+};
+
+export type DeleteTaskParams = {
+  task_guid: TaskDeletePayload["path"]["task_guid"];
+};
+
+export type GetTaskParams = {
+  task_guid: TaskGetPayload["path"]["task_guid"];
+  user_id_type?: NonNullable<TaskGetPayload["params"]>["user_id_type"];
+};
+
+export type UpdateTaskParams = {
+  task_guid: TaskUpdatePayload["path"]["task_guid"];
+  task: TaskUpdateTask;
+  update_fields?: TaskUpdateData["update_fields"];
+  user_id_type?: NonNullable<TaskUpdatePayload["params"]>["user_id_type"];
+};
+
+const TaskDateSchema = Type.Object({
+  timestamp: Type.Optional(
+    Type.String({
+      description:
+        "Unix timestamp in milliseconds (string), e.g. \"1735689600000\" (13-digit ms)",
+    }),
+  ),
+  is_all_day: Type.Optional(Type.Boolean({ description: "Whether this is an all-day date" })),
+});
+
+const TaskMemberSchema = Type.Object({
+  id: Type.String({ description: "Member ID (with type controlled by user_id_type)" }),
+  type: Type.Optional(Type.String({ description: "Member type (usually \"user\")" })),
+  role: Type.String({ description: "Member role, e.g. \"assignee\"" }),
+  name: Type.Optional(Type.String({ description: "Optional display name" })),
+});
+
+const TasklistRefSchema = Type.Object({
+  tasklist_guid: Type.Optional(Type.String({ description: "Tasklist GUID" })),
+  section_guid: Type.Optional(Type.String({ description: "Section GUID in tasklist" })),
+});
+
+export const CreateTaskSchema = Type.Object({
+  summary: Type.String({ description: "Task title/summary" }),
+  description: Type.Optional(Type.String({ description: "Task description" })),
+  due: Type.Optional(TaskDateSchema),
+  start: Type.Optional(TaskDateSchema),
+  extra: Type.Optional(Type.String({ description: "Custom opaque metadata string" })),
+  completed_at: Type.Optional(
+    Type.String({
+      description: "Completion time as Unix timestamp in milliseconds (string, 13-digit ms)",
+    }),
+  ),
+  members: Type.Optional(Type.Array(TaskMemberSchema, { description: "Initial task members" })),
+  repeat_rule: Type.Optional(Type.String({ description: "Task repeat rule" })),
+  tasklists: Type.Optional(
+    Type.Array(TasklistRefSchema, { description: "Attach the task to tasklists/sections" }),
+  ),
+  mode: Type.Optional(Type.Number({ description: "Task mode value from Feishu Task API" })),
+  is_milestone: Type.Optional(Type.Boolean({ description: "Whether task is a milestone" })),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type for member IDs, e.g. open_id/user_id/union_id",
+    }),
+  ),
+});
+
+export const DeleteTaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to delete" }),
+});
+
+export const GetTaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to retrieve" }),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type in returned members, e.g. open_id/user_id/union_id",
+    }),
+  ),
+});
+
+const TaskUpdateContentSchema = Type.Object(
+  {
+    summary: Type.Optional(Type.String({ description: "Updated summary" })),
+    description: Type.Optional(Type.String({ description: "Updated description" })),
+    due: Type.Optional(TaskDateSchema),
+    start: Type.Optional(TaskDateSchema),
+    extra: Type.Optional(Type.String({ description: "Updated extra metadata" })),
+    completed_at: Type.Optional(
+      Type.String({
+        description: "Updated completion time (Unix timestamp in milliseconds, string, 13-digit ms)",
+      }),
+    ),
+    repeat_rule: Type.Optional(Type.String({ description: "Updated repeat rule" })),
+    mode: Type.Optional(Type.Number({ description: "Updated task mode" })),
+    is_milestone: Type.Optional(Type.Boolean({ description: "Updated milestone flag" })),
+  },
+  { minProperties: 1 },
+);
+
+export const UpdateTaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to update" }),
+  task: TaskUpdateContentSchema,
+  update_fields: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        "Fields to update. If omitted, this tool infers from keys in task (e.g. summary, description, due, start)",
+      minItems: 1,
+    }),
+  ),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type when task body contains user-related fields",
+    }),
+  ),
+});

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,0 +1,1 @@
+export { registerFeishuTaskTools } from "./task-tools/register.js";

--- a/src/tools-common/feishu-api.ts
+++ b/src/tools-common/feishu-api.ts
@@ -1,0 +1,184 @@
+/**
+ * Minimal response shape shared by Feishu OpenAPI endpoints.
+ * Most endpoints return success when `code` is `0` (or omitted).
+ */
+export type FeishuApiResponse = {
+  code?: number;
+  msg?: string;
+  log_id?: string;
+  logId?: string;
+};
+
+type FeishuErrorInfo = {
+  code?: number;
+  msg?: string;
+  logId?: string;
+};
+
+type RunFeishuApiCallOptions = {
+  /** Feishu error codes that should be treated as transient and retried. */
+  retryableCodes?: Iterable<number>;
+  /** Retry delays in milliseconds. Number of entries controls retry attempts. */
+  backoffMs?: number[];
+};
+
+/**
+ * Standard tool result payload:
+ * - `content` for model-visible text output
+ * - `details` for structured downstream access
+ */
+export function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+/** Convert any thrown value into the standard JSON error envelope. */
+export function errorResult(err: unknown) {
+  return json({ error: err instanceof Error ? err.message : String(err) });
+}
+
+/** Small async sleep utility used by retry backoff. */
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Extract Feishu error fields (`code`, `msg`, `log_id`) from different throw shapes.
+ * Handles nested SDK error arrays and axios-style `response.data`.
+ */
+function extractFeishuErrorInfo(err: unknown): FeishuErrorInfo | null {
+  if (!err) return null;
+
+  // Feishu SDK may throw nested array structures like:
+  // [axiosError, { code, msg, log_id, ... }]
+  if (Array.isArray(err)) {
+    for (let i = err.length - 1; i >= 0; i -= 1) {
+      const info = extractFeishuErrorInfo(err[i]);
+      if (info) return info;
+    }
+    return null;
+  }
+
+  if (typeof err !== "object") return null;
+
+  const obj = err as Record<string, unknown>;
+  const codeValue = obj.code;
+  const msgValue = obj.msg ?? obj.message;
+  const logIdValue = obj.log_id ?? obj.logId;
+
+  const hasCode = typeof codeValue === "number";
+  const hasMsg = typeof msgValue === "string";
+  const hasLogId = typeof logIdValue === "string";
+
+  if (hasCode || hasMsg || hasLogId) {
+    return {
+      code: hasCode ? codeValue : undefined,
+      msg: hasMsg ? (msgValue as string) : undefined,
+      logId: hasLogId ? (logIdValue as string) : undefined,
+    };
+  }
+
+  const responseData = (obj.response as { data?: unknown } | undefined)?.data;
+  if (responseData) return extractFeishuErrorInfo(responseData);
+
+  return null;
+}
+
+function assertFeishuOk<T extends FeishuApiResponse>(response: T, context: string): T {
+  if (response.code === undefined || response.code === 0) return response;
+
+  const message = response.msg || `code ${response.code}`;
+  const detail = response.log_id ?? response.logId;
+  const error = new Error(
+    detail
+      ? `${context} failed: ${message}, code=${response.code}, log_id=${detail}`
+      : `${context} failed: ${message}, code=${response.code}`,
+  ) as Error & { code?: number; log_id?: string; logId?: string };
+  error.code = response.code;
+  if (detail) {
+    error.log_id = detail;
+    error.logId = detail;
+  }
+  throw error;
+}
+
+/**
+ * Normalize unknown errors to a readable, context-aware Error message.
+ * Preserves Feishu `code/log_id` details when available.
+ */
+function toError(err: unknown, context: string): Error {
+  if (err instanceof Error) {
+    const info = extractFeishuErrorInfo(err);
+    if (!info) return err;
+    const details = [
+      info.msg || `code ${info.code}`,
+      info.code !== undefined ? `code=${info.code}` : undefined,
+      info.logId ? `log_id=${info.logId}` : undefined,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    return new Error(`${context} failed: ${details}`);
+  }
+
+  const info = extractFeishuErrorInfo(err);
+  if (info) {
+    const details = [
+      info.msg || `code ${info.code}`,
+      info.code !== undefined ? `code=${info.code}` : undefined,
+      info.logId ? `log_id=${info.logId}` : undefined,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    return new Error(`${context} failed: ${details}`);
+  }
+
+  return new Error(`${context} failed: ${String(err)}`);
+}
+
+/**
+ * Execute a Feishu API call with shared success/error handling.
+ *
+ * Behavior:
+ * - Treats `code === 0` (or undefined) as success.
+ * - Converts non-zero responses and thrown values into normalized Errors.
+ * - Optionally retries only for configured transient error codes.
+ *
+ * Retry model:
+ * - Attempts = `backoffMs.length + 1`
+ * - Delay before each retry uses the corresponding `backoffMs` entry.
+ */
+export async function runFeishuApiCall<T extends FeishuApiResponse>(
+  context: string,
+  fn: () => Promise<T>,
+  options?: RunFeishuApiCallOptions,
+): Promise<T> {
+  const retryableCodes = new Set(options?.retryableCodes ?? []);
+  const backoffMs = options?.backoffMs ?? [];
+  const maxAttempts = backoffMs.length + 1;
+  let attempt = 0;
+  let lastErr: unknown = null;
+
+  while (attempt < maxAttempts) {
+    try {
+      const response = await fn();
+      return assertFeishuOk(response, context);
+    } catch (err) {
+      lastErr = err;
+      const info = extractFeishuErrorInfo(err);
+      const retryable =
+        retryableCodes.size > 0 && info?.code !== undefined && retryableCodes.has(info.code);
+      const exhausted = attempt >= maxAttempts - 1;
+      if (!retryable || exhausted) {
+        throw toError(err, context);
+      }
+
+      const waitMs = backoffMs[Math.min(attempt, backoffMs.length - 1)];
+      await sleep(waitMs);
+      attempt += 1;
+    }
+  }
+
+  throw toError(lastErr, context);
+}

--- a/src/tools-config.ts
+++ b/src/tools-config.ts
@@ -2,7 +2,7 @@ import type { FeishuToolsConfig } from "./types.js";
 
 /**
  * Default tool configuration.
- * - doc, wiki, drive, scopes: enabled by default
+ * - doc, wiki, drive, scopes, task: enabled by default
  * - perm: disabled by default (sensitive operation)
  */
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
@@ -11,6 +11,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  task: true,
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  task?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {


### PR DESCRIPTION
## Summary
  This PR adds the first version of Feishu Task tooling to the plugin, focused on
  core task operations.

  ## What’s included
  - Added new task tools:
    - `feishu_task_create`
    - `feishu_task_get`
    - `feishu_task_update`
    - `feishu_task_delete`
  - Added task tool schemas and strongly-typed SDK-based payload mappings.
  - Added `tools.task` config switch (default: enabled).
  - Registered task tools in plugin entrypoint.
  - Added shared Feishu OpenAPI helper module (`src/tools-common/feishu-api.ts`) for:
    - unified `json` / `errorResult` responses
    - normalized Feishu error extraction
    - shared API call wrapper with retry support
  - Refactored bitable common helpers to reuse the new shared API layer.
  - Updated README (English + Chinese):
    - documented Task tools
    - updated task scopes to `task:task:read` and `task:task:write`
    - clarified time-related task params use millisecond timestamps where applicable

  ## Permission reminder
  Please make sure the Feishu app has both Task scopes enabled and approved:
  - `task:task:read` (required for `feishu_task_get`)
  - `task:task:write` (required for `feishu_task_create`, `feishu_task_update`,
  `feishu_task_delete`)