### PR TITLE
fix: preserve topic context in outbound messages for sub-agent replies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ ref/**
 node_modules/
 dist/
 *.log
-.DS_Store
+.DS_Storem1heng-clawd-feishu-*.tgz

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -876,6 +876,12 @@ export async function handleFeishuMessage(params: {
       });
     }
 
+    // When the message is in a topic thread (has root_id), propagate it as
+    // MessageThreadId so that downstream reply routing (including sub-agent
+    // announces via the outbound adapter) can reply within the same topic
+    // instead of creating a new one.
+    const messageThreadId = isGroup && ctx.rootId ? ctx.rootId : undefined;
+
     const ctxPayload = core.channel.reply.finalizeInboundContext({
       Body: combinedBody,
       RawBody: ctx.content,
@@ -891,6 +897,7 @@ export async function handleFeishuMessage(params: {
       Provider: "feishu" as const,
       Surface: "feishu" as const,
       MessageSid: ctx.messageId,
+      MessageThreadId: messageThreadId,
       Timestamp: Date.now(),
       WasMentioned: ctx.mentionedBot,
       CommandAuthorized: true,

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -3,19 +3,40 @@ import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu } from "./send.js";
 import { sendMediaFeishu } from "./media.js";
 
+/**
+ * Resolve Feishu reply-to message ID from outbound context.
+ *
+ * In Feishu topic groups, replying to a message in a topic keeps the reply
+ * within that topic. Without a reply target, im.message.create() creates
+ * a new topic in the group — which is not desired for sub-agent results.
+ *
+ * Priority: explicit replyToId > threadId (stored as root_id from inbound).
+ */
+function resolveFeishuReplyToMessageId(
+  replyToId?: string | null,
+  threadId?: string | number | null,
+): string | undefined {
+  if (typeof replyToId === "string" && replyToId) return replyToId;
+  if (typeof threadId === "string" && threadId) return threadId;
+  return undefined;
+}
+
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: (text, limit) => getFeishuRuntime().channel.text.chunkMarkdownText(text, limit),
   chunkerMode: "markdown",
   textChunkLimit: 4000,
-  sendText: async ({ cfg, to, text, accountId }) => {
-    const result = await sendMessageFeishu({ cfg, to, text, accountId });
+  sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
+    const replyToMessageId = resolveFeishuReplyToMessageId(replyToId, threadId);
+    const result = await sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId, threadId }) => {
+    const replyToMessageId = resolveFeishuReplyToMessageId(replyToId, threadId);
+
     // Send text first if provided
     if (text?.trim()) {
-      await sendMessageFeishu({ cfg, to, text, accountId });
+      await sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
     }
 
     // Upload and send media if URL provided
@@ -28,13 +49,13 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         console.error(`[feishu] sendMediaFeishu failed:`, err);
         // Fallback to URL link if upload fails
         const fallbackText = `📎 ${mediaUrl}`;
-        const result = await sendMessageFeishu({ cfg, to, text: fallbackText, accountId });
+        const result = await sendMessageFeishu({ cfg, to, text: fallbackText, accountId, replyToMessageId });
         return { channel: "feishu", ...result };
       }
     }
 
     // No media URL, just return text result
-    const result = await sendMessageFeishu({ cfg, to, text: text ?? "", accountId });
+    const result = await sendMessageFeishu({ cfg, to, text: text ?? "", accountId, replyToMessageId });
     return { channel: "feishu", ...result };
   },
 };


### PR DESCRIPTION
## Problem

When `topicSessionMode` is enabled and a sub-agent (`sessions_spawn`) delivers results back to a Feishu topic group, the messages **create new topics** instead of appearing in the original conversation thread.

Direct replies work correctly — only sub-agent announces and outbound delivery (e.g., `message` tool, cron job delivery) are affected.

## Root Cause

Two pieces were missing from the outbound delivery path:

### 1. `bot.ts` — Missing `MessageThreadId` propagation

The inbound message handler did not propagate `root_id` (Feishu's topic identifier) as `MessageThreadId` to the session's delivery context. Without this, the session has no record of which topic the conversation belongs to, so downstream delivery cannot route back to the correct topic.

### 2. `outbound.ts` — Ignored `replyToId` and `threadId` parameters

The outbound adapter destructured only `{ cfg, to, text, accountId }` from the `ChannelOutboundContext`, discarding `replyToId` and `threadId` that the delivery pipeline provides. This meant even when the framework passed topic context, the Feishu adapter always used `im.message.create()` without a reply target — which in Feishu topic groups **creates a new topic**.

## Fix

### `bot.ts`
Set `MessageThreadId` to `root_id` for group messages that are part of a topic thread. This persists the topic's root message ID in the session delivery context, making it available for downstream delivery.

```typescript
const messageThreadId = isGroup && ctx.rootId ? ctx.rootId : undefined;
// ... passed to finalizeInboundContext as MessageThreadId
```

### `outbound.ts`
Accept `replyToId` and `threadId` from the `ChannelOutboundContext` and resolve them to a `replyToMessageId` for Feishu API calls.

Priority: explicit `replyToId` > `threadId` (root_id stored in session).

When present, messages use `im.message.reply()` which keeps them in the existing topic instead of creating a new one.

```typescript
function resolveFeishuReplyToMessageId(
  replyToId?: string | null,
  threadId?: string | number | null,
): string | undefined {
  if (typeof replyToId === "string" && replyToId) return replyToId;
  if (typeof threadId === "string" && threadId) return threadId;
  return undefined;
}
```

## How it works end-to-end

1. User sends message in Feishu topic → `bot.ts` stores `root_id` as `MessageThreadId`
2. Session delivery context now includes `threadId: root_id`
3. Sub-agent completes → announce flow reads `threadId` from session context
4. Delivery pipeline passes `threadId` to outbound adapter
5. `outbound.ts` uses it as `replyToMessageId` → `im.message.reply()` → message stays in topic ✅

## Note on OpenClaw core

For the full fix to work with sub-agent announces, OpenClaw core's `resolveFallbackSession()` in `outbound-session.js` also needs to forward the `threadId` parameter and encode it into the peer ID for topic-scoped session keys. Without that, the `threadId` never reaches the outbound adapter for plugin-based channels. This is tracked separately as an OpenClaw core issue.

## Testing

- Verified `tsc --noEmit` passes with no errors
- Confirmed new sessions correctly store `threadId` in delivery context
- Confirmed direct replies continue to work (no regression)