### PR TITLE
fix: propagate topic threadId for outbound message routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ ref/**
 node_modules/
 dist/
 *.log
-.DS_Store
+.DS_Storem1heng-clawd-feishu-0.1.9.tgz

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -891,6 +891,9 @@ export async function handleFeishuMessage(params: {
       Provider: "feishu" as const,
       Surface: "feishu" as const,
       MessageSid: ctx.messageId,
+      // Propagate topic root_id as MessageThreadId so the session's
+      // deliveryContext carries threadId for outbound routing.
+      MessageThreadId: isGroup && ctx.rootId ? ctx.rootId : undefined,
       Timestamp: Date.now(),
       WasMentioned: ctx.mentionedBot,
       CommandAuthorized: true,

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -8,14 +8,21 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunker: (text, limit) => getFeishuRuntime().channel.text.chunkMarkdownText(text, limit),
   chunkerMode: "markdown",
   textChunkLimit: 4000,
-  sendText: async ({ cfg, to, text, accountId }) => {
-    const result = await sendMessageFeishu({ cfg, to, text, accountId });
+  sendText: async ({ cfg, to, text, accountId, threadId }) => {
+    // When threadId is provided (e.g., from message tool auto-threading or
+    // sub-agent announces routed back to a topic thread), use it as
+    // replyToMessageId so the message is placed inside the existing Feishu
+    // topic instead of creating a new one.
+    const replyToMessageId = threadId ? String(threadId) : undefined;
+    const result = await sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, threadId }) => {
+    const replyToMessageId = threadId ? String(threadId) : undefined;
+
     // Send text first if provided
     if (text?.trim()) {
-      await sendMessageFeishu({ cfg, to, text, accountId });
+      await sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
     }
 
     // Upload and send media if URL provided
@@ -28,13 +35,13 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         console.error(`[feishu] sendMediaFeishu failed:`, err);
         // Fallback to URL link if upload fails
         const fallbackText = `📎 ${mediaUrl}`;
-        const result = await sendMessageFeishu({ cfg, to, text: fallbackText, accountId });
+        const result = await sendMessageFeishu({ cfg, to, text: fallbackText, accountId, replyToMessageId });
         return { channel: "feishu", ...result };
       }
     }
 
     // No media URL, just return text result
-    const result = await sendMessageFeishu({ cfg, to, text: text ?? "", accountId });
+    const result = await sendMessageFeishu({ cfg, to, text: text ?? "", accountId, replyToMessageId });
     return { channel: "feishu", ...result };
   },
 };


### PR DESCRIPTION
## Problem

When `topicSessionMode` is enabled, messages sent via the `message` tool or sub-agent announces create new Feishu topics instead of staying within the existing topic thread.

The root cause has two layers:
1. **Inbound**: `finalizeInboundContext` doesn't pass `root_id` as `MessageThreadId`, so the session's `deliveryContext` has no `threadId`
2. **Outbound**: `sendText`/`sendMedia` don't accept or forward `threadId`, so even if threadId is available, it's not used

## Changes

### bot.ts
- Pass `root_id` as `MessageThreadId` in `finalizeInboundContext` (only for group messages with `root_id`)
- This populates `deliveryContext.threadId` in the session, which is used by OpenClaw core for outbound routing

### outbound.ts
- Accept `threadId` parameter in `sendText` and `sendMedia`
- Convert to `replyToMessageId` for the Feishu API (`im.message.reply`), which places the message within the existing topic

## Related

- OpenClaw core PR: https://github.com/openclaw/openclaw/pull/13970 (auto-injects threadId from session context into message tool)
- Supersedes #232 (same fix, rebased on latest main)