### PR TITLE
feat: add import_document action for better markdown import

### DIFF
--- a/src/drive-schema.ts
+++ b/src/drive-schema.ts
@@ -11,6 +11,11 @@ const FileType = Type.Union([
   Type.Literal("shortcut"),
 ]);
 
+const DocType = Type.Union([
+  Type.Literal("docx", { description: "New generation document (default)" }),
+  Type.Literal("doc", { description: "Legacy document" }),
+]);
+
 export const FeishuDriveSchema = Type.Union([
   Type.Object({
     action: Type.Literal("list"),
@@ -40,6 +45,21 @@ export const FeishuDriveSchema = Type.Union([
     action: Type.Literal("delete"),
     file_token: Type.String({ description: "File token to delete" }),
     type: FileType,
+  }),
+  Type.Object({
+    action: Type.Literal("import_document"),
+    title: Type.String({
+      description: "Document title",
+    }),
+    content: Type.String({
+      description: "Markdown content to import. Supports full Markdown syntax including tables, lists, code blocks, etc.",
+    }),
+    folder_token: Type.Optional(
+      Type.String({
+        description: "Target folder token (optional, defaults to root). Use 'list' to find folder tokens.",
+      }),
+    ),
+    doc_type: Type.Optional(DocType),
   }),
 ]);
 


### PR DESCRIPTION
## Summary

Add new `import_document` action to `feishu_drive` tool that creates documents from markdown with better structure preservation than the block-by-block insertion method.

## Changes

- Add `import_document` action to `feishu_drive` tool
- Export `writeDoc` function from `docx.ts` for reuse
- Add batch insertion and error handling for large content
- Add content length warnings and block batching (50 blocks/batch)
- Fallback to individual block insertion if batch fails

## Usage

```json
{
  "action": "import_document",
  "title": "Document Title",
  "content": "# Markdown Content...",
  "folder_token": "optional_folder_token",
  "doc_type": "docx"
}
```

## Benefits

- Better structure preservation for complex markdown (tables, nested lists)
- Handles large content with automatic batching
- Graceful degradation when API limits are hit

Fixes #239