### PR TITLE
feat: enable onboarding CLI for multi-agent to multi-account bot   binding

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,5 +1,5 @@
 import type { ChannelPlugin, ClawdbotConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId, PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk";
 import type { ResolvedFeishuAccount, FeishuConfig } from "./types.js";
 import {
   resolveFeishuAccount,
@@ -222,7 +222,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
     },
   },
   setup: {
-    resolveAccountId: () => DEFAULT_ACCOUNT_ID,
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
     applyAccountConfig: ({ cfg, accountId }) => {
       const isDefault = !accountId || accountId === DEFAULT_ACCOUNT_ID;
       


### PR DESCRIPTION
Extends Feishu onboarding CLI to support linking one Feishu channel to multiple agents and multiple bot accounts, with per-agent/per-account binding to avoid cross-account routing. Bot app setup and required configuration remain aligned with the README.

# OpenClaw Feishu Agent Add Flow (English)

  ## 1. Start the wizard
  ```bash
  openclaw agents add 
  
  or 

  pnpm openclaw agents add (if local dev)

  ```

  ## 2. Fill basic agent fields

  1. Enter Agent name (example: clawdbot-feishu-5).
  2. Enter Workspace directory (example: ~/.openclaw/workspace-clawdbot-feishu-
     5).
  3. Choose whether to copy auth profiles from main (usually Yes).

  ## 3. Configure model/auth

  1. Select Configure model/auth for this agent now? → Yes.
  2. Select the model provider (for example, Moonshot / Kimi K2.5).
  3. Select auth method.
  4. Enter the provider API key.

  ## 4. Configure channel

  1. Select Configure chat channels now? → Yes.
  2. Select Feishu/Lark.
  3. If Feishu is already configured, choose Modify settings.
  4. Under Feishu account, choose Add a new account.
  5. Enter new Feishu account id (example: lobster-5).
  6. Enter Feishu App ID for that account.
  7. Enter Feishu App Secret for that account.
  8. Wait for connection test result.
  9. Select Feishu domain.
  10. Select group chat policy.
  11. Finish channel selection.

  ## 5. Configure DM policy

  1. Select Configure DM access policies now? → Yes.
  2. Select DM policy (for example: open).

  ## 6. Bind route to this agent

  1. Select Route selected channels to this agent now? (bindings) → Yes.

  ## 7. Success output

  You should see:

  - Updated ~/.openclaw/openclaw.json
  - Workspace OK: ...
  - Sessions OK: ...
  - Agent "<agent-id>" ready

扩展了飞书 onboarding CLI，支持在同一个 Feishu channel 下关联多个 agent 和多个  bot 账号，并通过按 agent/账号的绑定避免跨账号路由错乱。Bot 应用的创建与配置方式保持与 README 一致。


  # OpenClaw 新增 Feishu Agent 完整流程（中文）

  ## 1. 启动向导
  ```bash
  openclaw agents add

  或者

  pnpm openclaw agents add （本地开发）  

  ```

  ## 2. 填写 Agent 基础信息

  1. 输入 Agent name（例如：clawdbot-feishu-5）。
  2. 输入 Workspace directory（例如：~/.openclaw/workspace-clawdbot-feishu-5）。
  3. 选择是否从 main 复制 auth profiles（通常选 Yes）。

  ## 3. 配置模型与鉴权

  1. 选择 Configure model/auth for this agent now? → Yes。
  2. 选择模型供应商（例如 Moonshot / Kimi K2.5）。
  3. 选择鉴权方式。
  4. 输入模型 API Key。

  ## 4. 配置渠道

  1. 选择 Configure chat channels now? → Yes。
  2. 选择 Feishu/Lark。
  3. 如果 Feishu 已配置，选择 Modify settings。
  4. 在 Feishu account 中选择 Add a new account。
  5. 输入新的 Feishu account id（例如：lobster-5）。
  6. 输入该账号的 Feishu App ID。
  7. 输入该账号的 Feishu App Secret。
  8. 等待连接测试结果。
  9. 选择 Feishu 域名。
  10. 选择群聊策略。
  11. 完成渠道选择。

  ## 5. 配置 DM 策略

  1. 选择 Configure DM access policies now? → Yes。
  2. 选择 DM policy（例如：open）。

  ## 6. 绑定路由到该 Agent

  1. 选择 Route selected channels to this agent now? (bindings) → Yes。

  ## 7. 成功标志

  完成后应看到：

  - Updated ~/.openclaw/openclaw.json
  - Workspace OK: ...
  - Sessions OK: ...
  - Agent "<agent-id>" ready