### PR TITLE
fix(feishu): route tools by active account

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -25,6 +25,7 @@ import {
   isMentionForwardRequest,
 } from "./mention.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
+import { runWithFeishuToolContext } from "./tools-common/tool-context.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
 // --- Message deduplication ---
@@ -837,12 +838,21 @@ export async function handleFeishuMessage(params: {
 
       log(`feishu[${account.accountId}]: dispatching permission error notification to agent`);
 
-      await core.channel.reply.dispatchReplyFromConfig({
-        ctx: permissionCtx,
-        cfg,
-        dispatcher: permDispatcher,
-        replyOptions: permReplyOptions,
-      });
+      await runWithFeishuToolContext(
+        {
+          channel: "feishu",
+          accountId: account.accountId,
+          sessionKey: route.sessionKey,
+        },
+        // Keep account context available while the agent executes plugin tools.
+        () =>
+          core.channel.reply.dispatchReplyFromConfig({
+            ctx: permissionCtx,
+            cfg,
+            dispatcher: permDispatcher,
+            replyOptions: permReplyOptions,
+          }),
+      );
 
       markPermIdle();
     }
@@ -911,12 +921,21 @@ export async function handleFeishuMessage(params: {
 
     log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
 
-    const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
-      ctx: ctxPayload,
-      cfg,
-      dispatcher,
-      replyOptions,
-    });
+    const { queuedFinal, counts } = await runWithFeishuToolContext(
+      {
+        channel: "feishu",
+        accountId: account.accountId,
+        sessionKey: route.sessionKey,
+      },
+      // Tool calls produced by this turn should resolve to the same inbound account.
+      () =>
+        core.channel.reply.dispatchReplyFromConfig({
+          ctx: ctxPayload,
+          cfg,
+          dispatcher,
+          replyOptions,
+        }),
+    );
 
     markDispatchIdle();
 

--- a/src/task-tools/register.ts
+++ b/src/task-tools/register.ts
@@ -1,8 +1,6 @@
 import type { TSchema } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { listEnabledFeishuAccounts } from "../accounts.js";
-import { createFeishuClient } from "../client.js";
-import { resolveToolsConfig } from "../tools-config.js";
+import { hasFeishuToolEnabledForAnyAccount, withFeishuToolClient } from "../tools-common/tool-exec.js";
 import { createTask, deleteTask, getTask, updateTask } from "./actions.js";
 import { errorResult, json, type TaskClient } from "./common.js";
 import {
@@ -26,7 +24,6 @@ type ToolSpec<P> = {
 
 function registerTaskTool<P>(
   api: OpenClawPluginApi,
-  getClient: () => TaskClient,
   spec: ToolSpec<P>,
 ) {
   api.registerTool(
@@ -37,7 +34,12 @@ function registerTaskTool<P>(
       parameters: spec.parameters,
       async execute(_toolCallId, params) {
         try {
-          return json(await spec.run(getClient(), params as P));
+          return await withFeishuToolClient({
+            api,
+            toolName: spec.name,
+            requiredTool: "task",
+            run: async ({ client }) => json(await spec.run(client as TaskClient, params as P)),
+          });
         } catch (err) {
           return errorResult(err);
         }
@@ -53,22 +55,17 @@ export function registerFeishuTaskTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
-  if (accounts.length === 0) {
+  if (!hasFeishuToolEnabledForAnyAccount(api.config)) {
     api.logger.debug?.("feishu_task: No Feishu accounts configured, skipping task tools");
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
-  if (!toolsCfg.task) {
+  if (!hasFeishuToolEnabledForAnyAccount(api.config, "task")) {
     api.logger.debug?.("feishu_task: task tools disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
-
-  registerTaskTool<CreateTaskParams>(api, getClient, {
+  registerTaskTool<CreateTaskParams>(api, {
     name: "feishu_task_create",
     label: "Feishu Task Create",
     description: "Create a Feishu task (task v2)",
@@ -76,7 +73,7 @@ export function registerFeishuTaskTools(api: OpenClawPluginApi) {
     run: (client, params) => createTask(client, params),
   });
 
-  registerTaskTool<DeleteTaskParams>(api, getClient, {
+  registerTaskTool<DeleteTaskParams>(api, {
     name: "feishu_task_delete",
     label: "Feishu Task Delete",
     description: "Delete a Feishu task by task_guid (task v2)",
@@ -84,7 +81,7 @@ export function registerFeishuTaskTools(api: OpenClawPluginApi) {
     run: (client, { task_guid }) => deleteTask(client, task_guid),
   });
 
-  registerTaskTool<GetTaskParams>(api, getClient, {
+  registerTaskTool<GetTaskParams>(api, {
     name: "feishu_task_get",
     label: "Feishu Task Get",
     description: "Get Feishu task details by task_guid (task v2)",
@@ -92,7 +89,7 @@ export function registerFeishuTaskTools(api: OpenClawPluginApi) {
     run: (client, params) => getTask(client, params),
   });
 
-  registerTaskTool<UpdateTaskParams>(api, getClient, {
+  registerTaskTool<UpdateTaskParams>(api, {
     name: "feishu_task_update",
     label: "Feishu Task Update",
     description: "Update a Feishu task by task_guid (task v2 patch)",
@@ -100,5 +97,5 @@ export function registerFeishuTaskTools(api: OpenClawPluginApi) {
     run: (client, params) => updateTask(client, params),
   });
 
-  api.logger.info?.("feishu_task: Registered 4 task tools");
+  api.logger.debug?.("feishu_task: Registered 4 task tools");
 }

--- a/src/tools-common/tool-context.ts
+++ b/src/tools-common/tool-context.ts
@@ -1,0 +1,23 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type FeishuToolContext = {
+  channel: "feishu";
+  accountId: string;
+  sessionKey?: string;
+};
+
+const toolContextStorage = new AsyncLocalStorage<FeishuToolContext>();
+
+export function runWithFeishuToolContext<T>(
+  context: FeishuToolContext,
+  fn: () => T,
+): T {
+  // Propagate the active Feishu account through async boundaries so tool execution
+  // can resolve the correct account without changing OpenClaw core APIs.
+  return toolContextStorage.run(context, fn);
+}
+
+export function getCurrentFeishuToolContext(): FeishuToolContext | undefined {
+  // Returns undefined when execution is outside a message-dispatch context.
+  return toolContextStorage.getStore();
+}

--- a/src/tools-common/tool-exec.ts
+++ b/src/tools-common/tool-exec.ts
@@ -1,0 +1,73 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { ClawdbotConfig, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import {
+  listEnabledFeishuAccounts,
+  resolveDefaultFeishuAccountId,
+  resolveFeishuAccount,
+} from "../accounts.js";
+import { createFeishuClient } from "../client.js";
+import { resolveToolsConfig } from "../tools-config.js";
+import { getCurrentFeishuToolContext } from "./tool-context.js";
+import type { FeishuToolsConfig, ResolvedFeishuAccount } from "../types.js";
+
+export type FeishuToolFlag = keyof Required<FeishuToolsConfig>;
+
+export function hasFeishuToolEnabledForAnyAccount(
+  cfg: ClawdbotConfig,
+  requiredTool?: FeishuToolFlag,
+): boolean {
+  // Tool registration is global (one definition), so we only need to know whether
+  // at least one enabled account can use the tool.
+  const accounts = listEnabledFeishuAccounts(cfg);
+  if (accounts.length === 0) {
+    return false;
+  }
+  if (!requiredTool) {
+    return true;
+  }
+  return accounts.some((account) => resolveToolsConfig(account.config.tools)[requiredTool]);
+}
+
+export function resolveToolAccount(cfg: ClawdbotConfig): ResolvedFeishuAccount {
+  const context = getCurrentFeishuToolContext();
+  if (context?.channel === "feishu" && context.accountId) {
+    // Message-driven path: use the account from AsyncLocalStorage context.
+    return resolveFeishuAccount({ cfg, accountId: context.accountId });
+  }
+  // Non-session path (e.g. background/manual invocation): fall back to default account.
+  return resolveFeishuAccount({ cfg, accountId: resolveDefaultFeishuAccountId(cfg) });
+}
+
+export async function withFeishuToolClient<T>(params: {
+  api: OpenClawPluginApi;
+  toolName: string;
+  requiredTool?: FeishuToolFlag;
+  run: (args: { client: Lark.Client; account: ResolvedFeishuAccount }) => Promise<T>;
+}): Promise<T> {
+  if (!params.api.config) {
+    throw new Error("Feishu config is not available");
+  }
+
+  // Resolve account at execution time (not registration time).
+  const account = resolveToolAccount(params.api.config);
+
+  if (!account.enabled) {
+    throw new Error(`Feishu account "${account.accountId}" is disabled`);
+  }
+  if (!account.configured) {
+    throw new Error(`Feishu account "${account.accountId}" is not configured`);
+  }
+
+  if (params.requiredTool) {
+    // Enforce per-account tool toggles, even though the tool is registered globally.
+    const toolsCfg = resolveToolsConfig(account.config.tools);
+    if (!toolsCfg[params.requiredTool]) {
+      throw new Error(
+        `Feishu tool "${params.toolName}" is disabled for account "${account.accountId}"`,
+      );
+    }
+  }
+
+  const client = createFeishuClient(account);
+  return params.run({ client, account });
+}

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -1,9 +1,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { createFeishuClient } from "./client.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { FeishuWikiSchema, type FeishuWikiParams } from "./wiki-schema.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import { hasFeishuToolEnabledForAnyAccount, withFeishuToolClient } from "./tools-common/tool-exec.js";
 
 // ============ Helpers ============
 
@@ -155,20 +153,15 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
-  if (accounts.length === 0) {
+  if (!hasFeishuToolEnabledForAnyAccount(api.config)) {
     api.logger.debug?.("feishu_wiki: No Feishu accounts configured, skipping wiki tools");
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
-  if (!toolsCfg.wiki) {
+  if (!hasFeishuToolEnabledForAnyAccount(api.config, "wiki")) {
     api.logger.debug?.("feishu_wiki: wiki tool disabled in config");
     return;
   }
-
-  const getClient = () => createFeishuClient(firstAccount);
 
   api.registerTool(
     {
@@ -180,38 +173,44 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
       async execute(_toolCallId, params) {
         const p = params as FeishuWikiParams;
         try {
-          const client = getClient();
-          switch (p.action) {
-            case "spaces":
-              return json(await listSpaces(client));
-            case "nodes":
-              return json(await listNodes(client, p.space_id, p.parent_node_token));
-            case "get":
-              return json(await getNode(client, p.token));
-            case "search":
-              return json({
-                error:
-                  "Search is not available. Use feishu_wiki with action: 'nodes' to browse or action: 'get' to lookup by token.",
-              });
-            case "create":
-              return json(
-                await createNode(client, p.space_id, p.title, p.obj_type, p.parent_node_token),
-              );
-            case "move":
-              return json(
-                await moveNode(
-                  client,
-                  p.space_id,
-                  p.node_token,
-                  p.target_space_id,
-                  p.target_parent_token,
-                ),
-              );
-            case "rename":
-              return json(await renameNode(client, p.space_id, p.node_token, p.title));
-            default:
-              return json({ error: `Unknown action: ${(p as any).action}` });
-          }
+          return await withFeishuToolClient({
+            api,
+            toolName: "feishu_wiki",
+            requiredTool: "wiki",
+            run: async ({ client }) => {
+              switch (p.action) {
+                case "spaces":
+                  return json(await listSpaces(client));
+                case "nodes":
+                  return json(await listNodes(client, p.space_id, p.parent_node_token));
+                case "get":
+                  return json(await getNode(client, p.token));
+                case "search":
+                  return json({
+                    error:
+                      "Search is not available. Use feishu_wiki with action: 'nodes' to browse or action: 'get' to lookup by token.",
+                  });
+                case "create":
+                  return json(
+                    await createNode(client, p.space_id, p.title, p.obj_type, p.parent_node_token),
+                  );
+                case "move":
+                  return json(
+                    await moveNode(
+                      client,
+                      p.space_id,
+                      p.node_token,
+                      p.target_space_id,
+                      p.target_parent_token,
+                    ),
+                  );
+                case "rename":
+                  return json(await renameNode(client, p.space_id, p.node_token, p.title));
+                default:
+                  return json({ error: `Unknown action: ${(p as any).action}` });
+              }
+            },
+          });
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
         }
@@ -220,5 +219,5 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     { name: "feishu_wiki" },
   );
 
-  api.logger.info?.(`feishu_wiki: Registered feishu_wiki tool`);
+  api.logger.debug?.("feishu_wiki: Registered feishu_wiki tool");
 }


### PR DESCRIPTION
Should support route tools by active account after this pr merged. https://github.com/m1heng/clawdbot-feishu/pull/248

## Summary

This PR fixes Feishu tool execution in multi-account setups by selecting the runtime account at tool execution time (not registration time), and reduces registration log noise by moving those messages from info to debug.

## Problem

In multi-account mode, several Feishu tool modules used a “first account” assumption during registration (accounts[0]).
That could route tool calls (doc/wiki/drive/task/perm/bitable) to the wrong bot account.

## Solution

### 1) Runtime account routing for tools

- Added async context propagation for inbound Feishu turns:
    - src/tools-common/tool-context.ts
- Wrapped Feishu agent dispatch with account context:
    - src/bot.ts
- Added a shared tool execution wrapper:
    - src/tools-common/tool-exec.ts

The wrapper does:

- Resolve account from async context when available
- Fallback to default Feishu account for non-session/background invocations
- Enforce account enabled/configured checks
- Enforce per-account tool toggle checks
- Build Feishu client for the resolved account

### 2) Remove first-account assumptions in tool modules

Updated modules to use the shared execution wrapper instead of pre-binding firstAccount:

- src/docx.ts
- src/wiki.ts
- src/drive.ts
- src/perm.ts
- src/task-tools/register.ts
- src/bitable-tools/register.ts

Registration remains global (single tool definition), while account selection is done per execution.

## Behavior after this PR

- Inbound Feishu message from account A -> tool calls execute with account A
- Inbound Feishu message from account B -> tool calls execute with account B
- Non-session invocations -> fallback to default Feishu account
- Tool enable flags are evaluated per resolved account
- Tool defaults are unchanged (doc/wiki/drive/scopes/task on, perm off)

## Scope

- Plugin-only changes
- No OpenClaw core changes
- No tool schema/name changes (backward compatible)