### PR TITLE
fix: Auto-detect file type for feishu_drive.delete and feishu_drive.info

### DIFF
--- a/src/drive-schema.ts
+++ b/src/drive-schema.ts
@@ -26,7 +26,7 @@ export const FeishuDriveSchema = Type.Union([
   Type.Object({
     action: Type.Literal("info"),
     file_token: Type.String({ description: "File or folder token" }),
-    type: FileType,
+    type: Type.Optional(FileType),
   }),
   Type.Object({
     action: Type.Literal("create_folder"),
@@ -44,7 +44,7 @@ export const FeishuDriveSchema = Type.Union([
   Type.Object({
     action: Type.Literal("delete"),
     file_token: Type.String({ description: "File token to delete" }),
-    type: FileType,
+    type: Type.Optional(FileType),
   }),
   Type.Object({
     action: Type.Literal("import_document"),


### PR DESCRIPTION
## Summary

This PR makes the `type` parameter optional for both `feishu_drive.delete` and `feishu_drive.info` actions, improving user experience by automatically detecting the file type when not explicitly provided.

## Changes

1. **Schema updates**:
   - Made `type` parameter optional in `feishu_drive.info` action
   - Made `type` parameter optional in `feishu_drive.delete` action

2. **New helper function**:
   - Added `getFileType` function that automatically detects file type with pagination support
   - Supports finding files across multiple pages of results

3. **Improvements**:
   - Updated `getFileInfo` to support pagination
   - Added debug logging for better troubleshooting
   - Returns `type_used` in delete action result for transparency
   - Graceful error handling when file cannot be found or type cannot be determined

## Usage Example

```
# Delete without specifying type (auto-detected)
feishu_drive.delete(file_token="docxxxxxxxxxx")

# Get info without specifying type (auto-detected)
feishu_drive.info(file_token="docxxxxxxxxxx")
```

Both actions still accept explicit `type` parameter for backward compatibility.