### PR TITLE
sync(feishu): align botOpenId mention gating with openclaw#16337

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -207,9 +207,8 @@ function parseMessageContent(content: string, messageType: string): string {
 function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boolean {
   const mentions = event.message.mentions ?? [];
   if (mentions.length === 0) return false;
-  // Fallback for degraded startup/probe scenarios: if botOpenId is unavailable,
-  // keep historical behavior and treat any mention as a mention trigger.
-  if (!botOpenId) return mentions.length > 0;
+  // Keep explicit bot mention semantics: without a resolved botOpenId, do not trigger.
+  if (!botOpenId) return false;
   return mentions.some((m) => m.id.open_id === botOpenId);
 }
 


### PR DESCRIPTION
## Summary
Sync bot mention gating behavior with official OpenClaw Feishu extension.

## Sync Source
- Upstream reference PR: https://github.com/openclaw/openclaw/pull/16337
- Synced file: `src/bot.ts`

## Change
- `checkBotMentioned` now follows official behavior:
  - if `botOpenId` is unresolved, treat group messages as **not mentioning** the bot.

## Problem Solved
- Eliminates behavior drift between this repository and official OpenClaw Feishu extension.
- Avoids accidental cross-bot trigger when `botOpenId` is missing/unresolved.

## Scope
- No other logic changes.
- No config/schema changes.
