### PR TITLE
fix: set ReplyToBody to make has_reply_context work correctly

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -932,6 +932,7 @@ export async function handleFeishuMessage(params: {
       CommandAuthorized: commandAuthorized,
       OriginatingChannel: "feishu" as const,
       OriginatingTo: feishuTo,
+      ReplyToBody: quotedContent,
       ...mediaPayload,
     });
 


### PR DESCRIPTION
## Summary

Fixes #265

### Problem
When Feishu bot received reply/forward messages in groups, the  field was always false, even though the message had reply/quote content.

### Root Cause
The code was fetching the quoted message content and embedding it in the message body as , but it wasn't setting the  field in the  call. OpenClaw calculates  based on , so without this field, it was always false.

### Solution
Add  to the  parameters.

### Changes
- : Added  field in the  call, passing the  value

### Verification
- ✅ TypeScript check passes ()
- ✅ Tested and verified working