### PR TITLE
feat: add document comment support (list_comments, get_comment)

### DIFF
--- a/src/doc-schema.ts
+++ b/src/doc-schema.ts
@@ -6,6 +6,17 @@ export const FeishuDocSchema = Type.Union([
     doc_token: Type.String({ description: "Document token (extract from URL /docx/XXX)" }),
   }),
   Type.Object({
+    action: Type.Literal("list_comments"),
+    doc_token: Type.String({ description: "Document token" }),
+    page_size: Type.Optional(Type.Number({ description: "Number of comments per page (default: 20, max: 100)" })),
+    page_token: Type.Optional(Type.String({ description: "Pagination token for next page" })),
+  }),
+  Type.Object({
+    action: Type.Literal("get_comment"),
+    doc_token: Type.String({ description: "Document token" }),
+    comment_id: Type.String({ description: "Comment ID (from list_comments or block.comment_ids)" }),
+  }),
+  Type.Object({
     action: Type.Literal("write"),
     doc_token: Type.String({ description: "Document token" }),
     content: Type.String({

--- a/src/docx.ts
+++ b/src/docx.ts
@@ -164,6 +164,49 @@ async function listAppScopes(client: Lark.Client) {
   };
 }
 
+async function listComments(
+  client: Lark.Client,
+  docToken: string,
+  pageSize?: number,
+  pageToken?: string,
+) {
+  const res = await client.request({
+    method: "GET",
+    url: `/open-apis/drive/v1/files/${docToken}/comments`,
+    params: {
+      file_type: "docx",
+      page_size: pageSize ?? 20,
+      ...(pageToken ? { page_token: pageToken } : {}),
+    },
+  });
+
+  if (res.code !== 0) throw new Error(res.msg);
+
+  return {
+    comments: res.data?.items ?? [],
+    page_token: res.data?.page_token,
+    has_more: res.data?.has_more ?? false,
+  };
+}
+
+async function getComment(client: Lark.Client, docToken: string, commentId: string) {
+  const res = await client.request({
+    method: "POST",
+    url: `/open-apis/drive/v1/files/${docToken}/comments/batch_query`,
+    params: { file_type: "docx" },
+    data: { comment_ids: [commentId] },
+  });
+
+  if (res.code !== 0) throw new Error(res.msg);
+
+  const comments = res.data?.items ?? [];
+  if (comments.length === 0) {
+    throw new Error(`Comment ${commentId} not found`);
+  }
+
+  return { comment: comments[0] };
+}
+
 // ============ Tool Registration ============
 
 export function registerFeishuDocTools(api: OpenClawPluginApi) {
@@ -189,7 +232,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
         name: "feishu_doc",
         label: "Feishu Doc",
         description:
-          'Feishu document operations. Actions: read, write, append, create, create_and_write, list_blocks, get_block, update_block, delete_block. Use "create_and_write" for atomic create + content write.',
+          'Feishu document operations. Actions: read, write, append, create, create_and_write, list_blocks, get_block, update_block, delete_block, list_comments, get_comment. Use "create_and_write" for atomic create + content write. Use "list_comments" and "get_comment" to retrieve document comments.',
         parameters: FeishuDocSchema,
         async execute(_toolCallId, params) {
           const p = params as FeishuDocParams;
@@ -227,6 +270,10 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                     return json(await updateBlock(client, p.doc_token, p.block_id, p.content));
                   case "delete_block":
                     return json(await deleteBlock(client, p.doc_token, p.block_id));
+                  case "list_comments":
+                    return json(await listComments(client, p.doc_token, p.page_size, p.page_token));
+                  case "get_comment":
+                    return json(await getComment(client, p.doc_token, p.comment_id));
                   default:
                     return json({ error: `Unknown action: ${(p as any).action}` });
                 }


### PR DESCRIPTION
## Summary

This PR adds support for retrieving document comments via the Feishu/Lark Drive API.

## New Actions

- : List all comments in a document with pagination support
- : Get detailed information about a specific comment including replies

## API Details

Both actions use the Drive API (not Docs API) to fetch comment data:
-  for listing
-  for getting specific comments

Note: The  parameter must be passed as a query parameter (not in the request body) due to Feishu API validation requirements.

## Use Cases

- Retrieve comments attached to specific text blocks (via )
- Display comment threads and replies in document operations
- Integration with document review workflows

## Example Usage



## Testing

- ✅  returns paginated comment list
- ✅  returns comment with quote text and reply list
- ✅ Error handling for non-existent comment IDs