### PR TITLE
fix(feishu): pass mediaLocalRoots through to loadWebMedia

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -451,11 +451,13 @@ export async function sendMediaFeishu(params: {
   to: string;
   mediaUrl?: string;
   mediaBuffer?: Buffer;
+  mediaLocalRoots?: readonly string[];
   fileName?: string;
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, mediaLocalRoots, fileName, replyToMessageId, accountId } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -472,6 +474,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
+      localRoots: mediaLocalRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId });
@@ -21,7 +21,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     // Upload and send media if URL provided
     if (mediaUrl) {
       try {
-        const result = await sendMediaFeishu({ cfg, to, mediaUrl, accountId });
+        const result = await sendMediaFeishu({ cfg, to, mediaUrl, mediaLocalRoots, accountId });
         return { channel: "feishu", ...result };
       } catch (err) {
         // Log the error for debugging


### PR DESCRIPTION
## Problem / 问题

`sendMediaFeishu` called `loadWebMedia` without `localRoots`, causing `LocalMediaAccessError: Local media path is not under an allowed directory` when the media source was a local file path (e.g. from an agent workspace).
`sendMediaFeishu` 调用 `loadWebMedia` 时未传入 `localRoots`，导致当媒体来源为本地文件路径（如 agent 工作区内的文件）时抛出 `LocalMediaAccessError: Local media path is not under an allowed directory`。

The error triggered the fallback, sending a plain text link `📎 <path>` instead of the actual file.
该错误会触发降级逻辑，最终只发送纯文本链接 `📎 <path>`，而非实际文件。

## Changes / 变更

- `sendMediaFeishu`: added `mediaLocalRoots?: readonly string[]` parameter, forwarded to `loadWebMedia` as `localRoots`
  `sendMediaFeishu`：新增 `mediaLocalRoots?: readonly string[]` 参数，并将其作为 `localRoots` 转发给 `loadWebMedia`
- `feishuOutbound.sendMedia`: destructures `mediaLocalRoots` from `ChannelOutboundContext` and passes it to `sendMediaFeishu`
  `feishuOutbound.sendMedia`：从 `ChannelOutboundContext` 中解构 `mediaLocalRoots`，并传入 `sendMediaFeishu`

## Notes / 备注

- Backward compatible — `mediaLocalRoots` is optional; callers that don't pass it fall back to default roots as before
  向后兼容 —— `mediaLocalRoots` 为可选参数，未传入时沿用原有默认根目录逻辑
- Matches the pattern already used by other channels (e.g. Telegram)
  与其他渠道（如 Telegram）已有的处理模式保持一致
