### PR TITLE
chore: add bilingual issue templates and manual triage setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report-en.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-en.yml
@@ -1,0 +1,121 @@
+name: "Bug Report (EN)"
+description: "Report a reproducible bug with required versions, setup method, and logs."
+title: "[Bug] "
+labels:
+  - type:bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide complete details so maintainers can reproduce quickly.
+
+  - type: checkboxes
+    id: precheck_search
+    attributes:
+      label: Pre-check
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression?
+      options:
+        - "Yes (worked before, broken now)"
+        - "No"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: input
+    id: openclaw_version
+    attributes:
+      label: OpenClaw Version
+      description: "Example: output of `openclaw --version`"
+      placeholder: "e.g. 2026.2.13"
+    validations:
+      required: true
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: Feishu Plugin Version
+      description: "Example: output from `openclaw plugins list`"
+      placeholder: "e.g. @m1heng-clawd/feishu 0.1.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_source
+    attributes:
+      label: Plugin Install Source
+      options:
+        - "npm package (openclaw plugins install @m1heng-clawd/feishu)"
+        - "local path (-l /path/to/clawdbot-feishu)"
+        - "local tarball (.tgz)"
+        - "other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: Steps to Reproduce
+      description: "Use numbered steps and include trigger actions."
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs (Optional)
+      description: "If available, include startup logs and logs around the failure window."
+      render: shell
+      placeholder: |
+        [startup]
+        ...
+
+        [when reproducing]
+        ...
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: "OS, Node.js version, deployment mode (local/docker/server)."
+      placeholder: "macOS 14.7, Node v22.x, local daemon"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: precheck_redacted
+    attributes:
+      label: Privacy Check
+      options:
+        - label: I removed secrets (appSecret, tokens, cookies, etc.) from config/logs.
+          required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: "Optional"

--- a/.github/ISSUE_TEMPLATE/02-config-integration-en.yml
+++ b/.github/ISSUE_TEMPLATE/02-config-integration-en.yml
@@ -1,0 +1,74 @@
+name: "Config or Integration Issue (EN)"
+description: "For setup/config issues (account mapping, event mode, permissions, routing)."
+title: "[Config] "
+labels:
+  - type:config
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for configuration and integration troubleshooting.
+
+  - type: input
+    id: openclaw_version
+    attributes:
+      label: OpenClaw Version
+      placeholder: "e.g. 2026.2.13"
+    validations:
+      required: true
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: Feishu Plugin Version
+      placeholder: "e.g. @m1heng-clawd/feishu 0.1.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: setup_method
+    attributes:
+      label: How Did You Configure?
+      options:
+        - "Manual openclaw.json edit"
+        - "openclaw config set commands"
+        - "Onboarding or UI"
+        - "Mixed"
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Target Setup
+      description: "What behavior are you trying to achieve?"
+      placeholder: "e.g. Two Feishu apps map to two different agents"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_config
+    attributes:
+      label: Relevant Config (Optional)
+      description: "Share relevant config sections if helpful."
+      render: json
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs (Optional)
+      render: shell
+      description: "If available, include startup logs and logs during the failing action."
+
+  - type: checkboxes
+    id: precheck_redacted
+    attributes:
+      label: Privacy Check
+      options:
+        - label: I removed secrets from logs/config.
+          required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Notes

--- a/.github/ISSUE_TEMPLATE/03-feature-request-en.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature-request-en.yml
@@ -1,0 +1,31 @@
+name: "Feature Request (EN)"
+description: "Describe your use case and expected behavior."
+title: "[Feature] "
+labels:
+  - type:feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the use case and expected behavior.
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+      description: "What scenario are you trying to support?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: "What should the plugin do?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Context (Optional)

--- a/.github/ISSUE_TEMPLATE/04-docs-improvement-en.yml
+++ b/.github/ISSUE_TEMPLATE/04-docs-improvement-en.yml
@@ -1,0 +1,49 @@
+name: "Documentation Improvement (EN)"
+description: "Report missing, incorrect, or unclear docs."
+title: "[Docs] "
+labels:
+  - type:docs
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Affected Doc Page
+      description: "Provide URL or file path."
+      placeholder: "e.g. README.md#event-subscriptions"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Doc Issue Type
+      options:
+        - "Incorrect"
+        - "Missing"
+        - "Outdated"
+        - "Unclear"
+        - "Translation"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_text
+    attributes:
+      label: Current Content (Optional)
+      description: "Quote the problematic part if possible."
+
+  - type: textarea
+    id: expected_text
+    attributes:
+      label: Suggested Fix
+      description: "Tell us what should be changed."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why This Matters
+      description: "How does this issue affect users?"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/05-question-en.yml
+++ b/.github/ISSUE_TEMPLATE/05-question-en.yml
@@ -1,0 +1,67 @@
+name: "Question (EN)"
+description: "Ask a usage question with enough context for troubleshooting."
+title: "[Question] "
+labels:
+  - type:question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when you need troubleshooting help.
+
+  - type: input
+    id: openclaw_version
+    attributes:
+      label: OpenClaw Version
+      description: "Example: output of `openclaw --version`"
+      placeholder: "e.g. 2026.2.13"
+    validations:
+      required: true
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: Feishu Plugin Version
+      description: "Example: output from `openclaw plugins list`"
+      placeholder: "e.g. @m1heng-clawd/feishu 0.1.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: setup_method
+    attributes:
+      label: Setup Method
+      options:
+        - "Manual openclaw.json edit"
+        - "openclaw config set commands"
+        - "Onboarding or UI"
+        - "Mixed"
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your Question
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant Config (Optional)
+      render: json
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs (Optional)
+      render: shell
+
+  - type: checkboxes
+    id: precheck_redacted
+    attributes:
+      label: Privacy Check
+      options:
+        - label: I removed secrets (appSecret, tokens, cookies, etc.) from config/logs.
+          required: true

--- a/.github/ISSUE_TEMPLATE/11-bug-report-zh.yml
+++ b/.github/ISSUE_TEMPLATE/11-bug-report-zh.yml
@@ -1,0 +1,121 @@
+name: "缺陷反馈（中文）"
+description: "提交可复现缺陷，请附版本、配置方式和日志。"
+title: "[Bug] "
+labels:
+  - type:bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请尽量完整填写，便于维护者快速复现和定位。
+
+  - type: checkboxes
+    id: precheck_search
+    attributes:
+      label: 提交前检查
+      options:
+        - label: 我已搜索现有 issue，未发现重复。
+          required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: 是否回归问题
+      options:
+        - "是（之前正常，现在异常）"
+        - "否"
+        - "不确定"
+    validations:
+      required: true
+
+  - type: input
+    id: openclaw_version
+    attributes:
+      label: OpenClaw 版本
+      description: "例如：`openclaw --version` 输出"
+      placeholder: "例如 2026.2.13"
+    validations:
+      required: true
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: 飞书插件版本
+      description: "例如：`openclaw plugins list` 输出"
+      placeholder: "例如 @m1heng-clawd/feishu 0.1.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_source
+    attributes:
+      label: 插件安装来源
+      options:
+        - "npm 包（openclaw plugins install @m1heng-clawd/feishu）"
+        - "本地路径（-l /path/to/clawdbot-feishu）"
+        - "本地 tarball（.tgz）"
+        - "其他"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: 复现步骤
+      description: "请使用编号步骤，并包含触发动作。"
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: 期望行为
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: 实际行为
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 相关日志（可选）
+      description: "如有可提供启动日志及故障窗口日志。"
+      render: shell
+      placeholder: |
+        [startup]
+        ...
+
+        [when reproducing]
+        ...
+
+  - type: textarea
+    id: env
+    attributes:
+      label: 环境信息
+      description: "操作系统、Node.js 版本、部署方式（本机/docker/服务器）。"
+      placeholder: "macOS 14.7, Node v22.x, 本机 daemon"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: precheck_redacted
+    attributes:
+      label: 隐私检查
+      options:
+        - label: 我已移除配置和日志中的敏感信息（appSecret、token、cookie 等）。
+          required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: 补充信息
+      description: "可选"

--- a/.github/ISSUE_TEMPLATE/12-config-integration-zh.yml
+++ b/.github/ISSUE_TEMPLATE/12-config-integration-zh.yml
@@ -1,0 +1,74 @@
+name: "配置或接入问题（中文）"
+description: "用于配置和接入排查（账号映射、事件模式、权限、路由）。"
+title: "[Config] "
+labels:
+  - type:config
+body:
+  - type: markdown
+    attributes:
+      value: |
+        该模板用于配置和接入问题排查。
+
+  - type: input
+    id: openclaw_version
+    attributes:
+      label: OpenClaw 版本
+      placeholder: "例如 2026.2.13"
+    validations:
+      required: true
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: 飞书插件版本
+      placeholder: "例如 @m1heng-clawd/feishu 0.1.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: setup_method
+    attributes:
+      label: 你是如何配置的？
+      options:
+        - "手工编辑 openclaw.json"
+        - "通过 openclaw config set 命令"
+        - "通过 onboarding 或 UI"
+        - "混合方式"
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: 目标配置
+      description: "你希望实现什么行为？"
+      placeholder: "例如：两个飞书应用分别映射到两个 agent"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_config
+    attributes:
+      label: 相关配置（可选）
+      description: "如有助于排查，可贴相关配置片段。"
+      render: json
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 相关日志（可选）
+      render: shell
+      description: "如有可提供启动日志及复现动作期间日志。"
+
+  - type: checkboxes
+    id: precheck_redacted
+    attributes:
+      label: 隐私检查
+      options:
+        - label: 我已移除日志和配置中的敏感信息。
+          required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: 其他补充

--- a/.github/ISSUE_TEMPLATE/13-feature-request-zh.yml
+++ b/.github/ISSUE_TEMPLATE/13-feature-request-zh.yml
@@ -1,0 +1,31 @@
+name: "功能建议（中文）"
+description: "请描述使用场景和期望行为。"
+title: "[Feature] "
+labels:
+  - type:feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请简要说明使用场景与期望行为。
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: 使用场景
+      description: "你希望支持的场景是什么？"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: 期望行为
+      description: "你希望插件具体怎么做？"
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: 补充信息（可选）

--- a/.github/ISSUE_TEMPLATE/14-docs-improvement-zh.yml
+++ b/.github/ISSUE_TEMPLATE/14-docs-improvement-zh.yml
@@ -1,0 +1,49 @@
+name: "文档改进（中文）"
+description: "反馈文档错误、缺失或表述不清。"
+title: "[Docs] "
+labels:
+  - type:docs
+body:
+  - type: input
+    id: page
+    attributes:
+      label: 涉及文档页面
+      description: "请提供 URL 或文件路径。"
+      placeholder: "例如 README.md#event-subscriptions"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: 文档问题类型
+      options:
+        - "内容错误"
+        - "信息缺失"
+        - "版本过期"
+        - "描述不清"
+        - "翻译问题"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_text
+    attributes:
+      label: 当前内容（可选）
+      description: "如方便，请贴出有问题的原文。"
+
+  - type: textarea
+    id: expected_text
+    attributes:
+      label: 建议修改
+      description: "请说明希望如何调整。"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: 影响说明
+      description: "该问题会如何影响使用者？"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/15-question-zh.yml
+++ b/.github/ISSUE_TEMPLATE/15-question-zh.yml
@@ -1,0 +1,67 @@
+name: "使用咨询（中文）"
+description: "提问使用问题（建议附版本、配置和日志，便于排查）。"
+title: "[Question] "
+labels:
+  - type:question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        该模板用于排查型咨询问题。
+
+  - type: input
+    id: openclaw_version
+    attributes:
+      label: OpenClaw 版本
+      description: "例如：`openclaw --version` 输出"
+      placeholder: "例如 2026.2.13"
+    validations:
+      required: true
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: 飞书插件版本
+      description: "例如：`openclaw plugins list` 输出"
+      placeholder: "例如 @m1heng-clawd/feishu 0.1.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: setup_method
+    attributes:
+      label: 配置方式
+      options:
+        - "手工编辑 openclaw.json"
+        - "通过 openclaw config set 命令"
+        - "通过 onboarding 或 UI"
+        - "混合方式"
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: 你的问题
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: 相关配置（可选）
+      render: json
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 相关日志（可选）
+      render: shell
+
+  - type: checkboxes
+    id: precheck_redacted
+    attributes:
+      label: 隐私检查
+      options:
+        - label: 我已移除配置和日志中的敏感信息（appSecret、token、cookie 等）。
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -1,0 +1,91 @@
+# Issue Triage Playbook
+
+[English](#english) | [中文](#中文)
+
+---
+
+## English
+
+### Goal
+
+Keep issue handling fast and reproducible with manual triage in the first phase.
+
+### Label Taxonomy
+
+- `type:*`: bug/config/feature/docs/question
+- `area:*`: channel/tools/docs (optional, maintainer-applied)
+
+### Definition of Ready (for engineering)
+
+Issue is ready when core context is present:
+
+1. OpenClaw version
+2. Feishu plugin version
+3. Setup method (`openclaw.json` manual / command / onboarding/UI)
+4. Repro steps (for bug/config issues)
+5. Logs around startup and failure window (optional, if available)
+
+If core context is missing, ask the reporter for the missing details.
+
+### Manual Triage Flow (v1)
+
+1. Confirm issue type and apply `type:*` label.
+2. Ask for missing context if needed.
+3. Reproduce and track progress manually in comments.
+
+### Maintainer Reply Template (missing info)
+
+```text
+Thanks for the report. To reproduce this reliably, please add:
+1) OpenClaw version
+2) Feishu plugin version
+3) Setup method (manual openclaw.json / command / onboarding/UI)
+4) Repro steps
+5) Relevant startup/runtime logs around the failure (optional, if available)
+
+After these are provided, we'll continue triage.
+```
+
+---
+
+## 中文
+
+### 目标
+
+第一阶段采用手动分诊，提升反馈处理效率与可复现性。
+
+### 标签体系
+
+- `type:*`：问题类型（bug/config/feature/docs/question）
+- `area:*`：模块标签（channel/tools/docs，可选，由维护者添加）
+
+### 进入开发前标准（Definition of Ready）
+
+以下核心信息齐全即可进入工程排查：
+
+1. OpenClaw 版本
+2. 飞书插件版本
+3. 配置方式（手工 `openclaw.json` / 命令行 / onboarding 或 UI）
+4. 可复现步骤（Bug/配置类 issue）
+5. 启动日志 + 复现窗口日志（可选，若有请提供）
+
+若核心信息缺失，请在评论中向提问者补充收集。
+
+### 手动分诊流程（v1）
+
+1. 确认问题类型并添加 `type:*` 标签。
+2. 如信息不足，评论追问关键上下文。
+3. 复现与进展先通过评论手动跟踪。
+
+### 维护者快捷回复模板（信息不足）
+
+```text
+感谢反馈。为了稳定复现，请补充以下信息：
+1）OpenClaw 版本
+2）飞书插件版本
+3）配置方式（手工 openclaw.json / 命令行 / onboarding 或 UI）
+4）可复现步骤
+5）故障前后相关启动/运行日志（可选，若有请提供）
+
+补充后我们会继续跟进。
+```

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,31 @@
+- name: type:bug
+  color: d73a4a
+  description: Something is broken and reproducible.
+
+- name: type:config
+  color: 1d76db
+  description: Configuration or integration issue.
+
+- name: type:feature
+  color: a2eeef
+  description: New feature or improvement proposal.
+
+- name: type:docs
+  color: 0075ca
+  description: Documentation issue or improvement.
+
+- name: type:question
+  color: d876e3
+  description: Usage question or troubleshooting request.
+
+- name: area:channel
+  color: 0366d6
+  description: Feishu channel runtime/message routing.
+
+- name: area:tools
+  color: 006b75
+  description: Feishu tools (doc/wiki/drive/perm/bitable/task).
+
+- name: area:docs
+  color: 5319e7
+  description: Documentation and examples.

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,24 @@
+name: Sync Labels
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/labels.yml
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels from .github/labels.yml
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          yaml-file: .github/labels.yml
+          skip-delete: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,36 @@ OpenClaw references:
 - Submit a Pull Request to fix bugs, add features, or improve docs.
 - Help review PRs and verify fixes from other contributors.
 
+### Issue Reporting Standard
+
+Use the GitHub Issue Forms and pick the correct type:
+
+- `Bug Report / 缺陷反馈`
+- `Config or Integration Issue / 配置或接入问题`
+- `Feature Request / 功能建议`
+- `Documentation Improvement / 文档改进`
+- `Question / 使用咨询`
+
+For usage questions, please use:
+
+- Open `Question` issue for troubleshooting with logs/config details.
+
+For bug/config issues, include this recommended context:
+
+- OpenClaw version
+- Feishu plugin version
+- Setup method (`openclaw.json` manual edit / CLI command / onboarding/UI)
+- Repro steps
+- Relevant startup and runtime logs
+
+Recommended commands to collect environment details:
+
+```bash
+openclaw --version
+openclaw plugins list | rg -i feishu
+node -v
+```
+
 ### Development requirements
 
 - Node.js `>= 22` (matches OpenClaw development requirement)
@@ -130,6 +160,36 @@ OpenClaw 参考文档：
 - 提交 Issue 讨论新功能需求。
 - 提交 Pull Request 修复 Bug、增加功能或改进文档。
 - 参与 PR 评审，协助验证其他贡献者的修复。
+
+### Issue 反馈规范
+
+请优先使用 GitHub Issue Forms，并选择正确类型：
+
+- `Bug Report / 缺陷反馈`
+- `Config or Integration Issue / 配置或接入问题`
+- `Feature Request / 功能建议`
+- `Documentation Improvement / 文档改进`
+- `Question / 使用咨询`
+
+使用咨询请使用：
+
+- 需要日志/配置排查时，提交 `Question` Issue。
+
+对于 Bug/配置问题，建议提供以下信息：
+
+- OpenClaw 版本
+- 飞书插件版本
+- 配置方式（手工 `openclaw.json` / 命令行 / onboarding 或 UI）
+- 可复现步骤
+- 相关启动日志和运行日志
+
+建议用于采集环境信息的命令：
+
+```bash
+openclaw --version
+openclaw plugins list | rg -i feishu
+node -v
+```
 
 ### 开发环境要求
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Feishu/Lark (飞书) channel plugin for [OpenClaw](https://github.com/openclaw/o
 > **中文社区资料** - 配置教程、常见问题、使用技巧：[Wiki](https://github.com/m1heng/clawdbot-feishu/wiki)
 >
 > **Contributing / 贡献指南**: [CONTRIBUTING.md](./CONTRIBUTING.md)
+>
+> **Issue Reporting / 问题反馈**: Please use structured Issue Forms with version and setup details; logs are optional.  
+> 请使用结构化 Issue 模板，并附版本与配置方式信息；日志为可选。
+>
+> **Questions / 使用咨询**: Please open a `Question` issue for usage troubleshooting.  
+> 使用咨询请提交 `Question` Issue。
 
 [English](#english) | [中文](#中文)
 


### PR DESCRIPTION
## Summary
- add bilingual GitHub Issue Forms for bug, config, feature, docs, and question
- enforce template-only issue creation (blank_issues_enabled false)
- add issue triage playbook for manual triage flow
- add label baseline (type and area labels) and label sync workflow
- update CONTRIBUTING.md and README.md with new issue-report guidance