### PR TITLE
chore: guide users to check discussions before opening issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report-en.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-en.yml
@@ -8,13 +8,14 @@ body:
     attributes:
       value: |
         Please provide complete details so maintainers can reproduce quickly.
+        Before filing, check Discussions for common fixes: https://github.com/m1heng/clawdbot-feishu/discussions
 
   - type: checkboxes
     id: precheck_search
     attributes:
       label: Pre-check
       options:
-        - label: I searched existing issues and did not find a duplicate.
+        - label: I searched existing issues and discussions and did not find an existing answer or duplicate.
           required: true
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/02-config-integration-en.yml
+++ b/.github/ISSUE_TEMPLATE/02-config-integration-en.yml
@@ -8,6 +8,15 @@ body:
     attributes:
       value: |
         This template is for configuration and integration troubleshooting.
+        Please check Discussions first: https://github.com/m1heng/clawdbot-feishu/discussions
+
+  - type: checkboxes
+    id: precheck_search
+    attributes:
+      label: Pre-check
+      options:
+        - label: I checked discussions and existing issues and did not find an existing answer or duplicate.
+          required: true
 
   - type: input
     id: openclaw_version

--- a/.github/ISSUE_TEMPLATE/03-feature-request-en.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature-request-en.yml
@@ -8,6 +8,7 @@ body:
     attributes:
       value: |
         Describe the use case and expected behavior.
+        Please check Discussions and existing issues first to avoid duplicates: https://github.com/m1heng/clawdbot-feishu/discussions
 
   - type: textarea
     id: use_case

--- a/.github/ISSUE_TEMPLATE/04-docs-improvement-en.yml
+++ b/.github/ISSUE_TEMPLATE/04-docs-improvement-en.yml
@@ -4,6 +4,12 @@ title: "[Docs] "
 labels:
   - type:docs
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check Discussions and existing issues first to avoid duplicates:
+        https://github.com/m1heng/clawdbot-feishu/discussions
+
   - type: input
     id: page
     attributes:

--- a/.github/ISSUE_TEMPLATE/05-question-en.yml
+++ b/.github/ISSUE_TEMPLATE/05-question-en.yml
@@ -8,6 +8,15 @@ body:
     attributes:
       value: |
         Use this template when you need troubleshooting help.
+        Please check Discussions first for common Q&A: https://github.com/m1heng/clawdbot-feishu/discussions
+
+  - type: checkboxes
+    id: precheck_search
+    attributes:
+      label: Pre-check
+      options:
+        - label: I checked discussions and existing issues and did not find an existing answer.
+          required: true
 
   - type: input
     id: openclaw_version

--- a/.github/ISSUE_TEMPLATE/11-bug-report-zh.yml
+++ b/.github/ISSUE_TEMPLATE/11-bug-report-zh.yml
@@ -8,13 +8,14 @@ body:
     attributes:
       value: |
         请尽量完整填写，便于维护者快速复现和定位。
+        提交前请先查看 Discussions 常见解答：https://github.com/m1heng/clawdbot-feishu/discussions
 
   - type: checkboxes
     id: precheck_search
     attributes:
       label: 提交前检查
       options:
-        - label: 我已搜索现有 issue，未发现重复。
+        - label: 我已搜索现有 issues 和 Discussions，未发现可直接复用的答案或重复问题。
           required: true
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/12-config-integration-zh.yml
+++ b/.github/ISSUE_TEMPLATE/12-config-integration-zh.yml
@@ -8,6 +8,15 @@ body:
     attributes:
       value: |
         该模板用于配置和接入问题排查。
+        提交前请先查看 Discussions：https://github.com/m1heng/clawdbot-feishu/discussions
+
+  - type: checkboxes
+    id: precheck_search
+    attributes:
+      label: 提交前检查
+      options:
+        - label: 我已搜索 Discussions 和现有 issues，未找到可直接复用的答案或重复问题。
+          required: true
 
   - type: input
     id: openclaw_version

--- a/.github/ISSUE_TEMPLATE/13-feature-request-zh.yml
+++ b/.github/ISSUE_TEMPLATE/13-feature-request-zh.yml
@@ -8,6 +8,7 @@ body:
     attributes:
       value: |
         请简要说明使用场景与期望行为。
+        提交前请先查看 Discussions 和现有 issues，避免重复建议：https://github.com/m1heng/clawdbot-feishu/discussions
 
   - type: textarea
     id: use_case

--- a/.github/ISSUE_TEMPLATE/14-docs-improvement-zh.yml
+++ b/.github/ISSUE_TEMPLATE/14-docs-improvement-zh.yml
@@ -4,6 +4,12 @@ title: "[Docs] "
 labels:
   - type:docs
 body:
+  - type: markdown
+    attributes:
+      value: |
+        提交前请先查看 Discussions 和现有 issues，避免重复反馈：
+        https://github.com/m1heng/clawdbot-feishu/discussions
+
   - type: input
     id: page
     attributes:

--- a/.github/ISSUE_TEMPLATE/15-question-zh.yml
+++ b/.github/ISSUE_TEMPLATE/15-question-zh.yml
@@ -8,6 +8,15 @@ body:
     attributes:
       value: |
         该模板用于排查型咨询问题。
+        提交前请先查看 Discussions 常见问答：https://github.com/m1heng/clawdbot-feishu/discussions
+
+  - type: checkboxes
+    id: precheck_search
+    attributes:
+      label: 提交前检查
+      options:
+        - label: 我已搜索 Discussions 和现有 issues，未找到可直接复用的答案。
+          required: true
 
   - type: input
     id: openclaw_version

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: "Q&A Discussions"
+    url: "https://github.com/m1heng/clawdbot-feishu/discussions"
+    about: "Check common Q&A/troubleshooting posts first; open an issue if no existing answer fits."
+  - name: "问答讨论（中文）"
+    url: "https://github.com/m1heng/clawdbot-feishu/discussions"
+    about: "请先查看常见问答/排查贴；若无匹配答案，再提交 issue。"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ OpenClaw references:
 
 ### Issue Reporting Standard
 
+Before opening an issue, search [Discussions](https://github.com/m1heng/clawdbot-feishu/discussions) and existing issues for known fixes or duplicates.
+
 Use the GitHub Issue Forms and pick the correct type:
 
 - `Bug Report / 缺陷反馈`
@@ -29,7 +31,8 @@ Use the GitHub Issue Forms and pick the correct type:
 
 For usage questions, please use:
 
-- Open `Question` issue for troubleshooting with logs/config details.
+- Use [Discussions](https://github.com/m1heng/clawdbot-feishu/discussions) for open-ended usage Q&A and idea exchange.
+- If no existing answer applies and troubleshooting details are needed, open a `Question` issue.
 
 For bug/config issues, include this recommended context:
 
@@ -163,6 +166,8 @@ OpenClaw 参考文档：
 
 ### Issue 反馈规范
 
+提交 issue 前，请先搜索 [Discussions](https://github.com/m1heng/clawdbot-feishu/discussions) 和现有 issues，确认是否已有解答或重复问题。
+
 请优先使用 GitHub Issue Forms，并选择正确类型：
 
 - `Bug Report / 缺陷反馈`
@@ -173,7 +178,8 @@ OpenClaw 参考文档：
 
 使用咨询请使用：
 
-- 需要日志/配置排查时，提交 `Question` Issue。
+- 开放式使用交流和想法讨论，使用 [Discussions](https://github.com/m1heng/clawdbot-feishu/discussions)。
+- 若 Discussions 中没有可用答案，且需要日志/配置排查，再提交 `Question` Issue。
 
 对于 Bug/配置问题，建议提供以下信息：
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Feishu/Lark (飞书) channel plugin for [OpenClaw](https://github.com/openclaw/o
 >
 > **Contributing / 贡献指南**: [CONTRIBUTING.md](./CONTRIBUTING.md)
 >
-> **Issue Reporting / 问题反馈**: Please use structured Issue Forms with version and setup details; logs are optional.  
-> 请使用结构化 Issue 模板，并附版本与配置方式信息；日志为可选。
+> **Issue Reporting / 问题反馈**: Please check [Discussions](https://github.com/m1heng/clawdbot-feishu/discussions) first for common solutions, then open a structured Issue Form if needed.  
+> 问题反馈前请先查看 [Discussions](https://github.com/m1heng/clawdbot-feishu/discussions) 是否已有常见解答；如仍未解决，再提交结构化 Issue 模板。
 >
-> **Questions / 使用咨询**: Please open a `Question` issue for usage troubleshooting.  
-> 使用咨询请提交 `Question` Issue。
+> **Questions / 使用咨询**: Use `Question` issue for troubleshooting; use [Discussions](https://github.com/m1heng/clawdbot-feishu/discussions) for open-ended Q&A.  
+> 排查型咨询请提交 `Question` Issue；开放式交流请使用 [Discussions](https://github.com/m1heng/clawdbot-feishu/discussions)。
 
 [English](#english) | [中文](#中文)
 


### PR DESCRIPTION
## Summary
- Add a Discussions-first intake path in issue entry points.
- Update README and CONTRIBUTING (EN/ZH) to guide users: check Discussions first, then open Issue when no existing answer fits.
- Update issue forms (EN/ZH):
  - Bug/Config/Question: add a required pre-check for searching Discussions + existing issues.
  - Feature/Docs: add lightweight reminder text to check Discussions/issues first.

## Why
Some Discussions already contain common troubleshooting answers. This change reduces duplicate issues and keeps issue reports focused on unresolved cases.

## Scope
- No runtime code changes.
- Issue process/documentation/templates only.