### PR TITLE
fix: use im.message.reply for streaming cards to support topic threading

### DIFF
--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -103,7 +103,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.log?.(`feishu[${account.accountId}] ${message}`),
       );
       try {
-        await streaming.start(chatId, resolveReceiveIdType(chatId));
+        await streaming.start(chatId, resolveReceiveIdType(chatId), replyToMessageId);
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;


### PR DESCRIPTION
## Problem

When streaming cards are enabled (`streaming: true`, `renderMode: "card"`), replies in Feishu group **topics/threads** appear in the main chat area instead of inside the topic thread.

## Root Cause

`FeishuStreamingSession.start()` uses `im.message.create()` to send the initial streaming card. This API does not support threading — the message always lands in the main chat, even when the triggering message came from a topic.

In contrast, regular (non-streaming) replies in `send.ts` correctly use `im.message.reply()` which threads the response into the topic.

## Fix

- Add an optional `replyToMessageId` parameter to `FeishuStreamingSession.start()`
- When `replyToMessageId` is provided, use `im.message.reply()` instead of `im.message.create()`
- Pass `replyToMessageId` from `reply-dispatcher.ts` into the streaming session

This aligns streaming card behavior with regular message replies.

## Files Changed

- `src/streaming-card.ts` — accept `replyToMessageId`, use `im.message.reply()` when provided
- `src/reply-dispatcher.ts` — pass `replyToMessageId` to `streaming.start()`

## Testing

Tested in a live Feishu group with topics enabled:
- Before fix: streaming card reply appears in main chat area
- After fix: streaming card reply correctly threads into the topic