### PR TITLE
fix: use mediaLocalRoots config when loading local media files

### DIFF
--- a/src/__tests__/config-schema.test.ts
+++ b/src/__tests__/config-schema.test.ts
@@ -72,4 +72,18 @@ describe("config-schema contract", () => {
     expect(parsed.accounts?.teamA?.tools?.doc).toBe(false);
     expect(parsed.accounts?.teamA?.tools?.task).toBe(true);
   });
+
+  it("Given mediaLocalRoots config, When parsing, Then top-level and account-level values are preserved", () => {
+    const parsed = FeishuConfigSchema.parse({
+      mediaLocalRoots: ["/tmp/custom"],
+      accounts: {
+        teamA: {
+          mediaLocalRoots: ["/data/media"],
+        },
+      },
+    });
+
+    expect(parsed.mediaLocalRoots).toEqual(["/tmp/custom"]);
+    expect(parsed.accounts?.teamA?.mediaLocalRoots).toEqual(["/data/media"]);
+  });
 });

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -97,6 +97,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         textChunkLimit: { type: "integer", minimum: 1 },
         chunkMode: { type: "string", enum: ["length", "newline"] },
         mediaMaxMb: { type: "number", minimum: 0 },
+        mediaLocalRoots: { type: "array", items: { type: "string" } },
         renderMode: { type: "string", enum: ["auto", "raw", "card"] },
         accounts: {
           type: "object",
@@ -111,6 +112,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
               verificationToken: { type: "string" },
               domain: { type: "string", enum: ["feishu", "lark"] },
               connectionMode: { type: "string", enum: ["websocket", "webhook"] },
+              mediaLocalRoots: { type: "array", items: { type: "string" } },
               groupCommandMentionBypass: { type: "string", enum: ["never", "single_bot", "always"] },
             },
           },

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -148,6 +148,7 @@ export const FeishuAccountConfigSchema = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema,
     mediaMaxMb: z.number().positive().optional(),
+    mediaLocalRoots: z.array(z.string()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     renderMode: RenderModeSchema,
     streaming: StreamingModeSchema,
@@ -185,6 +186,7 @@ export const FeishuConfigSchema = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema,
     mediaMaxMb: z.number().positive().optional(),
+    mediaLocalRoots: z.array(z.string()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     renderMode: RenderModeSchema, // raw = plain text (default), card = interactive card with markdown
     streaming: StreamingModeSchema,

--- a/src/media.ts
+++ b/src/media.ts
@@ -470,13 +470,30 @@ export async function sendMediaFeishu(params: {
     buffer = mediaBuffer;
     name = fileName ?? "file";
   } else if (mediaUrl) {
-    // Get mediaLocalRoots from config, fallback to default roots
-    const mediaLocalRoots = cfg.channels?.feishu?.mediaLocalRoots ?? [];
-    const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
-      maxBytes: mediaMaxBytes,
-      optimizeImages: false,
-      localRoots: mediaLocalRoots.length > 0 ? mediaLocalRoots : undefined,
-    });
+    const mediaLocalRoots = (account.config?.mediaLocalRoots ?? [])
+      .map((root) => root.trim())
+      .filter((root) => root.length > 0);
+    const loaded = await (async () => {
+      try {
+        return await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
+          maxBytes: mediaMaxBytes,
+          optimizeImages: false,
+        });
+      } catch (err) {
+        const shouldRetryWithCustomRoots =
+          mediaLocalRoots.length > 0 &&
+          err instanceof Error &&
+          err.message.includes("Local media path is not under an allowed directory");
+        if (!shouldRetryWithCustomRoots) {
+          throw err;
+        }
+        return await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
+          maxBytes: mediaMaxBytes,
+          optimizeImages: false,
+          localRoots: mediaLocalRoots,
+        });
+      }
+    })();
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";
   } else {


### PR DESCRIPTION
## Summary

This fix adds support for the  configuration option in the Feishu plugin.

## Problem

When users configure custom media directories in their  (e.g., ), the Feishu plugin was not using these custom directories when loading local media files. This caused file sending to fail for files outside the default allowed directories.

## Solution

In , the  function now reads the  configuration and passes it to .

## Testing

- Verified that files from  can be sent (worked before)
- Verified that files from custom directories can now be sent after adding them to 