### PR TITLE
fix(task): replace Type.Intersect with Type.Object spread in CreateSubtaskSchema

### DIFF
--- a/src/task-tools/schemas.ts
+++ b/src/task-tools/schemas.ts
@@ -300,12 +300,10 @@ export const CreateTaskSchema = Type.Object({
   ),
 });
 
-export const CreateSubtaskSchema = Type.Intersect([
-  Type.Object({
-    task_guid: Type.String({ description: "Parent task GUID" }),
-  }),
-  CreateTaskSchema,
-]);
+export const CreateSubtaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Parent task GUID" }),
+  ...CreateTaskSchema.properties,
+});
 
 export const DeleteTaskSchema = Type.Object({
   task_guid: Type.String({ description: "Task GUID to delete" }),


### PR DESCRIPTION
## Problem

`CreateSubtaskSchema` uses `Type.Intersect()` which generates a top-level `allOf` in the resulting JSON Schema. LLM function calling providers (Anthropic, OpenAI) reject schemas with top-level `allOf`, causing `feishu_task_subtask_create` to fail with:

```
Invalid schema for function 'feishu_task_subtask_create': ... must not have 'allOf' at the top level
```

## Fix

Replace `Type.Intersect([Type.Object({task_guid}), CreateTaskSchema])` with `Type.Object({task_guid, ...CreateTaskSchema.properties})` to produce a flat schema without `allOf`.

## Changes

- `src/task-tools/schemas.ts`: `CreateSubtaskSchema` definition (4 insertions, 6 deletions)

## Testing

Verified locally: `feishu_task_subtask_create` works correctly after this change.