### PR TITLE
fix(media): correct msg_type for audio/video and add duration/cover support

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^2.1.8",
     "@types/node": "^25.0.10",
+    "@vitest/coverage-v8": "^2.1.8",
     "openclaw": "2026.3.1",
     "tsx": "^4.21.0",
     "typescript": "^5.7.0",

--- a/src/__tests__/media-duration.test.ts
+++ b/src/__tests__/media-duration.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseOggDurationMs,
+  parseMp4DurationMs,
+  parseWavDurationMs,
+  parseFeishuMediaDurationMs,
+} from "../media-duration.js";
+
+// ---------------------------------------------------------------------------
+// Helpers to build minimal synthetic media buffers
+// ---------------------------------------------------------------------------
+
+/** Build a single OGG page. CRC is left as zero (not verified by the parser). */
+function makeOggPage(
+  granule: bigint,
+  serial: number,
+  sequence: number,
+  data: Buffer,
+  headerType: number,
+): Buffer {
+  const segments: number[] = [];
+  if (data.length === 0) {
+    segments.push(0);
+  } else {
+    let remaining = data.length;
+    while (remaining > 0) {
+      const seg = Math.min(255, remaining);
+      segments.push(seg);
+      remaining -= seg;
+      if (seg < 255) break;
+    }
+  }
+  const headerSize = 27 + segments.length;
+  const buf = Buffer.alloc(headerSize + data.length);
+  buf.write("OggS", 0, "ascii");
+  buf.writeUInt8(0, 4);
+  buf.writeUInt8(headerType, 5);
+  buf.writeUInt32LE(Number(granule & 0xffff_ffffn), 6);
+  buf.writeUInt32LE(Number((granule >> 32n) & 0xffff_ffffn), 10);
+  buf.writeUInt32LE(serial, 14);
+  buf.writeUInt32LE(sequence, 18);
+  buf.writeUInt32LE(0, 22); // CRC
+  buf.writeUInt8(segments.length, 26);
+  segments.forEach((s, i) => buf.writeUInt8(s, 27 + i));
+  data.copy(buf, headerSize);
+  return buf;
+}
+
+/** Build a minimal OGG/Opus buffer with the given granule position (samples at 48000 Hz). */
+function makeOpusBuffer(granuleSamples: number): Buffer {
+  // Opus identification header (19 bytes)
+  const opusHead = Buffer.from([
+    0x4f, 0x70, 0x75, 0x73, 0x48, 0x65, 0x61, 0x64, // "OpusHead"
+    0x01, 0x01, // version=1, channels=1
+    0x38, 0x01, // pre-skip=312 LE
+    0x80, 0xbb, 0x00, 0x00, // input_sample_rate=48000 LE
+    0x00, 0x00, 0x00, // output_gain=0, channel_mapping=0
+  ]);
+  const page1 = makeOggPage(0xffff_ffff_ffff_ffffn, 1, 0, opusHead, 0x02);
+  const page2 = makeOggPage(BigInt(granuleSamples), 1, 1, Buffer.alloc(0), 0x04);
+  return Buffer.concat([page1, page2]);
+}
+
+/** Build a minimal OGG/Vorbis buffer with the given granule position and sample rate. */
+function makeVorbisBuffer(granuleSamples: number, sampleRate: number): Buffer {
+  // Vorbis identification header (minimum 16 bytes needed for the parser)
+  const vorbisHead = Buffer.alloc(16);
+  vorbisHead.writeUInt8(0x01, 0); // packet type = identification
+  vorbisHead.write("vorbis", 1, "ascii");
+  // vorbis_version at offset 7 (4 bytes) = 0
+  vorbisHead.writeUInt8(1, 11); // audio_channels
+  vorbisHead.writeUInt32LE(sampleRate, 12); // audio_sample_rate
+  const page1 = makeOggPage(0xffff_ffff_ffff_ffffn, 1, 0, vorbisHead, 0x02);
+  const page2 = makeOggPage(BigInt(granuleSamples), 1, 1, Buffer.alloc(0), 0x04);
+  return Buffer.concat([page1, page2]);
+}
+
+/** Build a minimal MP4 buffer with a moov/mvhd box (version 0). */
+function makeMp4Buffer(timescale: number, duration: number): Buffer {
+  // mvhd v0: 4(size)+4(type)+1(ver)+3(flags)+4(ctime)+4(mtime)+4(tscale)+4(dur) = 28 bytes
+  const mvhdSize = 28;
+  const moovSize = 8 + mvhdSize;
+  const buf = Buffer.alloc(moovSize);
+  buf.writeUInt32BE(moovSize, 0);
+  buf.write("moov", 4, "ascii");
+  buf.writeUInt32BE(mvhdSize, 8);
+  buf.write("mvhd", 12, "ascii");
+  buf.writeUInt8(0, 16); // version = 0
+  // flags [17..19] = 0
+  // creation_time [20..23] = 0
+  // modification_time [24..27] = 0
+  buf.writeUInt32BE(timescale, 28);
+  buf.writeUInt32BE(duration, 32);
+  return buf;
+}
+
+/** Build a minimal MP4 buffer with a moov/mvhd box (version 1, 64-bit durations). */
+function makeMp4v1Buffer(timescale: number, duration: number): Buffer {
+  // mvhd v1: 4(size)+4(type)+1(ver)+3(flags)+8(ctime)+8(mtime)+4(tscale)+8(dur) = 40 bytes
+  const mvhdSize = 40;
+  const moovSize = 8 + mvhdSize;
+  const buf = Buffer.alloc(moovSize);
+  buf.writeUInt32BE(moovSize, 0);
+  buf.write("moov", 4, "ascii");
+  buf.writeUInt32BE(mvhdSize, 8);
+  buf.write("mvhd", 12, "ascii");
+  buf.writeUInt8(1, 16); // version = 1
+  // flags [17..19] = 0
+  // creation_time [20..27] = 0 (8 bytes)
+  // modification_time [28..35] = 0 (8 bytes)
+  buf.writeUInt32BE(timescale, 36);
+  buf.writeUInt32BE(0, 40); // durationHi
+  buf.writeUInt32BE(duration, 44); // durationLo
+  return buf;
+}
+
+/** Build a minimal WAV (PCM) buffer. dataBytes is the number of audio data bytes. */
+function makeWavBuffer(sampleRate: number, channels: number, dataBytes: number): Buffer {
+  const byteRate = sampleRate * channels * 2; // 16-bit samples
+  const buf = Buffer.alloc(44 + dataBytes);
+  buf.write("RIFF", 0, "ascii");
+  buf.writeUInt32LE(36 + dataBytes, 4);
+  buf.write("WAVE", 8, "ascii");
+  buf.write("fmt ", 12, "ascii");
+  buf.writeUInt32LE(16, 16); // fmt chunk size
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(channels, 22);
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(byteRate, 28);
+  buf.writeUInt16LE(channels * 2, 32); // block align
+  buf.writeUInt16LE(16, 34); // bits per sample
+  buf.write("data", 36, "ascii");
+  buf.writeUInt32LE(dataBytes, 40);
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("parseOggDurationMs", () => {
+  it("returns undefined for empty / non-OGG buffers", () => {
+    expect(parseOggDurationMs(Buffer.alloc(0))).toBeUndefined();
+    expect(parseOggDurationMs(Buffer.from("RIFF"))).toBeUndefined();
+    expect(parseOggDurationMs(Buffer.alloc(100))).toBeUndefined();
+  });
+
+  it("parses Opus duration (48000 Hz granule clock)", () => {
+    // 5 seconds = 48000 * 5 = 240000 samples
+    expect(parseOggDurationMs(makeOpusBuffer(240000))).toBe(5000);
+    // 1.5 seconds = 72000 samples → 1500ms
+    expect(parseOggDurationMs(makeOpusBuffer(72000))).toBe(1500);
+  });
+
+  it("parses Vorbis duration using stream sample rate", () => {
+    // 3 seconds at 44100 Hz = 132300 samples
+    expect(parseOggDurationMs(makeVorbisBuffer(132300, 44100))).toBe(3000);
+    // 2 seconds at 22050 Hz = 44100 samples
+    expect(parseOggDurationMs(makeVorbisBuffer(44100, 22050))).toBe(2000);
+  });
+
+  it("returns undefined when no valid granule position found", () => {
+    // Page with only -1 granule (no audio data)
+    const opusHead = Buffer.from([
+      0x4f, 0x70, 0x75, 0x73, 0x48, 0x65, 0x61, 0x64,
+      0x01, 0x01, 0x38, 0x01, 0x80, 0xbb, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    const onlyIdPage = makeOggPage(0xffff_ffff_ffff_ffffn, 1, 0, opusHead, 0x02);
+    expect(parseOggDurationMs(onlyIdPage)).toBeUndefined();
+  });
+});
+
+describe("parseMp4DurationMs", () => {
+  it("returns undefined for empty / non-MP4 buffers", () => {
+    expect(parseMp4DurationMs(Buffer.alloc(0))).toBeUndefined();
+    expect(parseMp4DurationMs(Buffer.from("OggS"))).toBeUndefined();
+    expect(parseMp4DurationMs(Buffer.alloc(100))).toBeUndefined();
+  });
+
+  it("parses mvhd version 0 duration", () => {
+    // timescale=1000, duration=5000 → 5000ms
+    expect(parseMp4DurationMs(makeMp4Buffer(1000, 5000))).toBe(5000);
+    // timescale=90000, duration=270000 → 3000ms
+    expect(parseMp4DurationMs(makeMp4Buffer(90000, 270000))).toBe(3000);
+  });
+
+  it("parses mvhd version 1 duration", () => {
+    // timescale=1000, duration=7500 → 7500ms
+    expect(parseMp4DurationMs(makeMp4v1Buffer(1000, 7500))).toBe(7500);
+  });
+
+  it("returns undefined when timescale is zero", () => {
+    expect(parseMp4DurationMs(makeMp4Buffer(0, 5000))).toBeUndefined();
+  });
+
+  it("skips non-moov top-level boxes before finding moov", () => {
+    // Prepend a 'free' box before the moov box
+    const freeBox = Buffer.alloc(16);
+    freeBox.writeUInt32BE(16, 0);
+    freeBox.write("free", 4, "ascii");
+    const moovBuf = makeMp4Buffer(1000, 2000);
+    const combined = Buffer.concat([freeBox, moovBuf]);
+    expect(parseMp4DurationMs(combined)).toBe(2000);
+  });
+});
+
+describe("parseWavDurationMs", () => {
+  it("returns undefined for empty / non-WAV buffers", () => {
+    expect(parseWavDurationMs(Buffer.alloc(0))).toBeUndefined();
+    expect(parseWavDurationMs(Buffer.from("OggS"))).toBeUndefined();
+    expect(parseWavDurationMs(Buffer.alloc(43))).toBeUndefined(); // too short
+  });
+
+  it("parses mono 16-bit PCM duration", () => {
+    // 44100 Hz mono 16-bit: byteRate = 88200; 1 second = 88200 bytes
+    expect(parseWavDurationMs(makeWavBuffer(44100, 1, 88200))).toBe(1000);
+    // 2.5 seconds
+    expect(parseWavDurationMs(makeWavBuffer(44100, 1, 88200 * 2.5))).toBe(2500);
+  });
+
+  it("parses stereo 16-bit PCM duration", () => {
+    // 48000 Hz stereo 16-bit: byteRate = 192000; 3 seconds = 576000 bytes
+    expect(parseWavDurationMs(makeWavBuffer(48000, 2, 576000))).toBe(3000);
+  });
+});
+
+describe("parseFeishuMediaDurationMs", () => {
+  it("routes 'mp4' to the MP4 parser", () => {
+    expect(parseFeishuMediaDurationMs(makeMp4Buffer(1000, 4000), "mp4")).toBe(4000);
+    expect(parseFeishuMediaDurationMs(makeOpusBuffer(48000), "mp4")).toBeUndefined();
+  });
+
+  it("routes 'opus' to OGG parser first", () => {
+    expect(parseFeishuMediaDurationMs(makeOpusBuffer(96000), "opus")).toBe(2000);
+  });
+
+  it("falls back to MP4 parser for M4A (opus type, MP4 container)", () => {
+    const m4aLike = makeMp4Buffer(44100, 132300); // ~3000ms
+    expect(parseFeishuMediaDurationMs(m4aLike, "opus")).toBe(3000);
+  });
+
+  it("falls back to WAV parser for opus type", () => {
+    const wav = makeWavBuffer(44100, 1, 44100 * 2); // 1000ms
+    expect(parseFeishuMediaDurationMs(wav, "opus")).toBe(1000);
+  });
+
+  it("returns undefined when no parser recognizes the buffer", () => {
+    expect(parseFeishuMediaDurationMs(Buffer.alloc(100), "opus")).toBeUndefined();
+    expect(parseFeishuMediaDurationMs(Buffer.alloc(100), "mp4")).toBeUndefined();
+  });
+});

--- a/src/media-duration.ts
+++ b/src/media-duration.ts
@@ -1,0 +1,190 @@
+/**
+ * Media duration parsers for Feishu file upload.
+ *
+ * Feishu's im.file.create API requires a `duration` (in ms) for audio and video
+ * so that the player shows the correct length and enables seeking.
+ *
+ * Supported containers:
+ *   - OGG  (Opus / Vorbis)  — used by Feishu voice messages and most AI TTS output
+ *   - MP4  (ISO base media) — MP4, MOV, QuickTime, M4A, M4V, 3GP share this format
+ *   - WAV  (RIFF PCM)       — uncompressed audio
+ *
+ * Formats intentionally skipped (complex frame-level parsing, rare in practice):
+ *   - MP3 (VBR makes byte-count estimation unreliable without scanning all frames)
+ *   - Raw AAC / ADTS
+ */
+
+/**
+ * Parse duration from an OGG container (Opus or Vorbis).
+ * Reads the granule position from the last OGG page and divides by sample rate.
+ * Returns duration in milliseconds, or undefined if not OGG or parsing fails.
+ */
+export function parseOggDurationMs(buffer: Buffer): number | undefined {
+  if (buffer.length < 27) return undefined;
+  // Verify OGG capture pattern "OggS"
+  if (buffer[0] !== 0x4f || buffer[1] !== 0x67 || buffer[2] !== 0x67 || buffer[3] !== 0x53) {
+    return undefined;
+  }
+
+  // Detect codec and sample rate from identification header (scan first 4 KB)
+  let sampleRate = 0;
+  const searchLen = Math.min(buffer.length, 4096);
+  for (let i = 0; i < searchLen - 8; i++) {
+    // "OpusHead" — Opus always uses 48000 Hz for granule positions
+    if (
+      buffer[i] === 0x4f && buffer[i + 1] === 0x70 && buffer[i + 2] === 0x75 &&
+      buffer[i + 3] === 0x73 && buffer[i + 4] === 0x48 && buffer[i + 5] === 0x65 &&
+      buffer[i + 6] === 0x61 && buffer[i + 7] === 0x64
+    ) {
+      sampleRate = 48000;
+      break;
+    }
+    // "\x01vorbis" — sample rate is uint32LE at +12 from start of tag
+    if (
+      buffer[i] === 0x01 && buffer[i + 1] === 0x76 && buffer[i + 2] === 0x6f &&
+      buffer[i + 3] === 0x72 && buffer[i + 4] === 0x62 && buffer[i + 5] === 0x69 &&
+      buffer[i + 6] === 0x73
+    ) {
+      if (i + 16 <= buffer.length) sampleRate = buffer.readUInt32LE(i + 12);
+      break;
+    }
+  }
+  if (sampleRate === 0) return undefined;
+
+  // Scan all OGG pages to find the highest valid granule position
+  let lastGranule = 0;
+  let offset = 0;
+  while (offset + 27 <= buffer.length) {
+    if (
+      buffer[offset] !== 0x4f || buffer[offset + 1] !== 0x67 ||
+      buffer[offset + 2] !== 0x67 || buffer[offset + 3] !== 0x53
+    ) break;
+    // Granule position: 8 bytes LE at offset+6; 0xFFFFFFFFFFFFFFFF means "no position"
+    const lo = buffer.readUInt32LE(offset + 6);
+    const hi = buffer.readUInt32LE(offset + 10);
+    if (lo !== 0xffffffff || hi !== 0xffffffff) {
+      const granule = hi * 0x100000000 + lo;
+      if (granule > lastGranule) lastGranule = granule;
+    }
+    const numSegments = buffer.readUInt8(offset + 26);
+    if (offset + 27 + numSegments > buffer.length) break;
+    let pageDataSize = 0;
+    for (let i = 0; i < numSegments; i++) pageDataSize += buffer.readUInt8(offset + 27 + i);
+    offset += 27 + numSegments + pageDataSize;
+  }
+
+  if (lastGranule <= 0) return undefined;
+  return Math.round((lastGranule / sampleRate) * 1000);
+}
+
+/**
+ * Parse duration from an ISO base media file format container (MP4 / MOV / M4A / QuickTime / 3GP).
+ * Reads the `mvhd` (movie header) box inside `moov`.
+ * Returns duration in milliseconds, or undefined if the box is not found.
+ */
+export function parseMp4DurationMs(buffer: Buffer): number | undefined {
+  // Find 'moov' box at the top level
+  let offset = 0;
+  let moovStart = -1;
+  let moovEnd = -1;
+  while (offset + 8 <= buffer.length) {
+    const boxSize = buffer.readUInt32BE(offset);
+    if (boxSize < 8) break;
+    if (buffer.toString("ascii", offset + 4, offset + 8) === "moov") {
+      moovStart = offset;
+      moovEnd = Math.min(offset + boxSize, buffer.length);
+      break;
+    }
+    offset += boxSize;
+  }
+  if (moovStart < 0) return undefined;
+
+  // Find 'mvhd' inside 'moov'
+  let inner = moovStart + 8;
+  while (inner + 8 <= moovEnd) {
+    const boxSize = buffer.readUInt32BE(inner);
+    if (boxSize < 8) break;
+    if (buffer.toString("ascii", inner + 4, inner + 8) === "mvhd") {
+      const version = buffer.readUInt8(inner + 8);
+      if (version === 0) {
+        // creation(4) + modification(4) + timescale(4) + duration(4)
+        if (inner + 28 > buffer.length) return undefined;
+        const timeScale = buffer.readUInt32BE(inner + 20);
+        const duration = buffer.readUInt32BE(inner + 24);
+        if (timeScale === 0) return undefined;
+        return Math.round((duration / timeScale) * 1000);
+      } else if (version === 1) {
+        // creation(8) + modification(8) + timescale(4) + duration(8)
+        if (inner + 40 > buffer.length) return undefined;
+        const timeScale = buffer.readUInt32BE(inner + 28);
+        const durationHi = buffer.readUInt32BE(inner + 32);
+        const durationLo = buffer.readUInt32BE(inner + 36);
+        const duration = durationHi * 0x100000000 + durationLo;
+        if (timeScale === 0) return undefined;
+        return Math.round((duration / timeScale) * 1000);
+      }
+      return undefined;
+    }
+    inner += boxSize;
+  }
+  return undefined;
+}
+
+/**
+ * Parse duration from a WAV (RIFF PCM) file.
+ * Computes duration from the `data` chunk size and the byte rate in the `fmt ` chunk.
+ * Returns duration in milliseconds, or undefined if not WAV or parsing fails.
+ */
+export function parseWavDurationMs(buffer: Buffer): number | undefined {
+  if (buffer.length < 44) return undefined;
+  if (buffer.toString("ascii", 0, 4) !== "RIFF") return undefined;
+  if (buffer.toString("ascii", 8, 12) !== "WAVE") return undefined;
+
+  let offset = 12;
+  let byteRate = 0;
+  let dataSize = 0;
+
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.toString("ascii", offset, offset + 4);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    if (chunkId === "fmt ") {
+      // fmt chunk layout (from chunk start):
+      //   +0  chunk id "fmt " (4)
+      //   +4  chunk size (4)
+      //   +8  audio format (2)
+      //   +10 num channels (2)
+      //   +12 sample rate (4)
+      //   +16 byte rate (4)  ← what we need
+      if (offset + 20 > buffer.length) return undefined;
+      byteRate = buffer.readUInt32LE(offset + 16);
+    } else if (chunkId === "data") {
+      dataSize = chunkSize;
+      break;
+    }
+    // Advance to next chunk; RIFF chunks are aligned to even byte boundaries
+    offset += 8 + chunkSize + (chunkSize % 2);
+  }
+
+  if (byteRate === 0 || dataSize === 0) return undefined;
+  return Math.round((dataSize / byteRate) * 1000);
+}
+
+/**
+ * Parse duration from a media buffer for Feishu upload.
+ *
+ * Routes to the appropriate parser based on Feishu's file type:
+ *   - "mp4"  → MP4/MOV/QuickTime container parser
+ *   - "opus" → OGG parser, then MP4 container (covers M4A), then WAV
+ *
+ * Returns duration in milliseconds, or undefined if not determinable.
+ */
+export function parseFeishuMediaDurationMs(
+  buffer: Buffer,
+  fileType: "opus" | "mp4",
+): number | undefined {
+  if (fileType === "mp4") {
+    return parseMp4DurationMs(buffer);
+  }
+  // fileType === "opus": try each container format in likelihood order
+  return parseOggDurationMs(buffer) ?? parseMp4DurationMs(buffer) ?? parseWavDurationMs(buffer);
+}

--- a/src/media.ts
+++ b/src/media.ts
@@ -3,6 +3,7 @@ import { createFeishuClient } from "./client.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { resolveReceiveIdType, normalizeFeishuTarget } from "./targets.js";
+import { parseFeishuMediaDurationMs } from "./media-duration.js";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -356,10 +357,12 @@ export async function sendFileFeishu(params: {
   fileKey: string;
   /** Use "audio" for audio, "media" for video, "file" for documents */
   msgType?: "file" | "audio" | "media";
+  /** Optional cover image key for video (msg_type "media") messages */
+  imageKey?: string;
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, fileKey, replyToMessageId, accountId } = params;
+  const { cfg, to, fileKey, imageKey, replyToMessageId, accountId } = params;
   const msgType = params.msgType ?? "file";
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
@@ -373,7 +376,10 @@ export async function sendFileFeishu(params: {
   }
 
   const receiveIdType = resolveReceiveIdType(receiveId);
-  const content = JSON.stringify({ file_key: fileKey });
+  const content = JSON.stringify({
+    file_key: fileKey,
+    ...(imageKey && { image_key: imageKey }),
+  });
 
   if (replyToMessageId) {
     const response = await client.im.message.reply({
@@ -421,12 +427,27 @@ export function detectFileType(
 ): "opus" | "mp4" | "pdf" | "doc" | "xls" | "ppt" | "stream" {
   const ext = path.extname(fileName).toLowerCase();
   switch (ext) {
+    // Audio formats → Feishu "opus" category
     case ".opus":
     case ".ogg":
+    case ".mp3":
+    case ".m4a":
+    case ".aac":
+    case ".wav":
+    case ".flac":
+    case ".wma":
+    case ".amr":
       return "opus";
+    // Video formats → Feishu "mp4" category
     case ".mp4":
     case ".mov":
     case ".avi":
+    case ".mkv":
+    case ".webm":
+    case ".flv":
+    case ".wmv":
+    case ".m4v":
+    case ".3gp":
       return "mp4";
     case ".pdf":
       return "pdf";
@@ -443,6 +464,7 @@ export function detectFileType(
       return "stream";
   }
 }
+
 
 /**
  * Upload and send media (image or file) from URL, local path, or buffer
@@ -465,6 +487,7 @@ export async function sendMediaFeishu(params: {
 
   let buffer: Buffer;
   let name: string;
+  let contentType: string | undefined;
 
   if (mediaBuffer) {
     buffer = mediaBuffer;
@@ -496,6 +519,7 @@ export async function sendMediaFeishu(params: {
     })();
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";
+    contentType = loaded.contentType;
   } else {
     throw new Error("Either mediaUrl or mediaBuffer must be provided");
   }
@@ -508,16 +532,27 @@ export async function sendMediaFeishu(params: {
     const { imageKey } = await uploadImageFeishu({ cfg, image: buffer, accountId });
     return sendImageFeishu({ cfg, to, imageKey, replyToMessageId, accountId });
   } else {
-    const fileType = detectFileType(name);
+    // Determine file type from extension; fall back to MIME type for files without
+    // a recognized extension (e.g. URLs with no filename, or buffers without fileName).
+    let fileType = detectFileType(name);
+    if (fileType === "stream" && contentType) {
+      if (contentType.startsWith("video/")) fileType = "mp4";
+      else if (contentType.startsWith("audio/")) fileType = "opus";
+    }
+    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
+    const duration =
+      fileType === "opus" || fileType === "mp4"
+        ? parseFeishuMediaDurationMs(buffer, fileType)
+        : undefined;
     const { fileKey } = await uploadFileFeishu({
       cfg,
       file: buffer,
       fileName: name,
       fileType,
+      duration,
       accountId,
     });
     // Feishu requires msg_type "audio" for audio, "media" for video, "file" for documents
-    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
     return sendFileFeishu({
       cfg,
       to,


### PR DESCRIPTION
## Problem

Fixes #344 Fixes #349: when the bot forwards audio/video files back to users, Feishu returns error 230055 (`file_type`/`msg_type` mismatch), and audio/video messages show incorrect duration or cannot seek.

## Root Causes

1. **`msg_type` mismatch**: files were uploaded with `file_type: "mp4"` but sent with `msg_type: "file"`, triggering Feishu error 230055.
2. **Missing `duration` field**: Feishu's `im.file.create` requires a `duration` parameter for audio/video so the player shows correct playback length and enables seeking. It was never passed.
3. **Incomplete format detection**: `detectFileType` originally only recognized `.mp4` and `.opus`; other common formats (`.mov`, `.mkv`, `.mp3`, `.m4a`, etc.) fell through to `"stream"`, causing downstream `msg_type` errors.

## Changes

### `src/media.ts`

- **`detectFileType`**: extended to cover common audio formats (ogg/mp3/m4a/aac/wav/flac/wma/amr → `"opus"`) and video formats (mov/avi/mkv/webm/flv/wmv/m4v/3gp → `"mp4"`).
- **`msg_type` routing**: `file_type: "opus"` → `msg_type: "audio"`, `file_type: "mp4"` → `msg_type: "media"`, everything else → `msg_type: "file"`.
- **MIME-type fallback**: for URLs without a file extension or buffers without a filename, falls back to `Content-Type` header when extension detection yields `"stream"` (`video/*` → `mp4`, `audio/*` → `opus`).
- **`sendFileFeishu`**: added optional `imageKey` parameter — when present it is included as `image_key` in the message content JSON, providing a video cover/thumbnail extension point for callers (auto frame extraction is out of scope for this PR).
- **`duration` plumbing**: parsed duration is forwarded to `uploadFileFeishu`, which already threads it through to the SDK's `im.file.create` call.

### `src/media-duration.ts` (new)

Self-contained duration parsing module with zero external dependencies:

| Parser | Formats | Approach |
|--------|---------|----------|
| `parseOggDurationMs` | OGG/Opus, OGG/Vorbis | Scans all OGG pages for the highest valid granule position; divides by sample rate (Opus: fixed 48000 Hz, Vorbis: read from identification header) |
| `parseMp4DurationMs` | MP4, MOV, M4A, QuickTime, 3GP | Walks top-level boxes to find `moov`, then finds `mvhd`; handles both version 0 (32-bit) and version 1 (64-bit) |
| `parseWavDurationMs` | WAV/RIFF PCM | Reads `byteRate` from the `fmt ` chunk and data size from the `data` chunk |
| `parseFeishuMediaDurationMs` | routing entry point | `"mp4"` → MP4 parser; `"opus"` → OGG → MP4 (covers M4A) → WAV |

**Dependency decision**: `music-metadata` was considered (it is what the Matrix channel uses) but ruled out because:
- It returns `undefined` duration for `video/quicktime` (MOV), so a manual MP4 parser would be required regardless.
- In the Feishu context, audio in practice is always OGG/Opus or M4A — the hand-written parsers cover 100% of real-world cases.
- Avoids adding ~1.6 MB of transitive dependencies for a narrow use case.

**WAV parser bug fix**: the original implementation read the `sampleRate` field (offset+12) instead of `byteRate` (offset+16), causing incorrect duration values. Fixed in this PR.

### `src/__tests__/media-duration.test.ts` (new)

Unit tests using minimal synthetic binary buffers, covering:
- Happy paths for all three parsers (MP4 v0/v1, Opus, Vorbis at various sample rates, WAV mono/stereo)
- Invalid/empty buffers returning `undefined`
- Edge cases: `timescale = 0`, truncated buffers
- MP4 box-skipping logic (non-`moov` boxes before `moov`)
- `parseFeishuMediaDurationMs` routing and each fallback in the `"opus"` chain

## Out of Scope

**Video cover image**: Feishu's `msg_type: "media"` content supports an `image_key` field for a cover thumbnail. Extracting a video frame requires `ffmpeg` and is not feasible in pure JS. The interface is already plumbed (`imageKey` parameter on `sendFileFeishu`); implementation is left for a follow-up.