### PR TITLE
fix(feishu): reply to topic root message in group threads

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1427,7 +1427,7 @@ export async function handleFeishuMessage(params: {
     }
 
     const envelopeFrom = isGroup ? `${ctx.chatId}:${ctx.senderOpenId}` : ctx.senderOpenId;
-    const replyToMessageId = replyToMessageIdOverride ?? ctx.messageId;
+    const replyToMessageId = replyToMessageIdOverride ?? ctx.rootId ?? ctx.messageId;
 
     // If there's a permission error, dispatch a separate notification first
     if (permissionErrorForAgent) {


### PR DESCRIPTION
## Summary
- Fix bot replies nesting under child messages instead of the topic root in topic groups
- Reply target now prefers `root_id` and falls back to `message_id` when absent

## Key Changes
### bot.ts
- Build `replyToMessageId` as `replyToMessageIdOverride ?? ctx.rootId ?? ctx.messageId`
- Preserves local `replyToMessageIdOverride` logic (not present in upstream)

## Source
Ported from [openclaw/openclaw@1234cc4](https://github.com/openclaw/openclaw/commit/1234cc4c3)
Original author: @bmendonca3
