### PR TITLE
fix(feishu): encode non-ASCII filenames in file uploads

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -238,6 +238,24 @@ export async function uploadImageFeishu(params: {
 }
 
 /**
+ * Encode a filename for safe use in Feishu multipart/form-data uploads.
+ * Non-ASCII characters (Chinese, em-dash, full-width brackets, etc.) cause
+ * the upload to silently fail when passed raw through the SDK's form-data
+ * serialization. RFC 5987 percent-encoding keeps headers 7-bit clean while
+ * Feishu's server decodes and preserves the original display name.
+ */
+export function sanitizeFileNameForUpload(fileName: string): string {
+  const ASCII_ONLY = /^[\x20-\x7E]+$/;
+  if (ASCII_ONLY.test(fileName)) {
+    return fileName;
+  }
+  return encodeURIComponent(fileName)
+    .replace(/'/g, "%27")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29");
+}
+
+/**
  * Upload a file to Feishu and get a file_key for sending.
  * Max file size: 30MB
  */
@@ -262,10 +280,12 @@ export async function uploadFileFeishu(params: {
   const fileStream =
     typeof file === "string" ? fs.createReadStream(file) : Readable.from(file);
 
+  const safeFileName = sanitizeFileNameForUpload(fileName);
+
   const response = await client.im.file.create({
     data: {
       file_type: fileType,
-      file_name: fileName,
+      file_name: safeFileName,
       file: fileStream as any,
       ...(duration !== undefined && { duration }),
     },


### PR DESCRIPTION
## Summary
- Fix silent upload failures when filenames contain non-ASCII characters (Chinese, em-dash, full-width punctuation, etc.)
- Add `sanitizeFileNameForUpload()` that RFC 5987 percent-encodes non-ASCII chars before passing to the Feishu SDK

## Key Changes
### media.ts
- **`sanitizeFileNameForUpload(fileName)`** — skips pure-ASCII names, percent-encodes everything else per RFC 5987
- `uploadFileFeishu` now passes `safeFileName` to the API instead of raw `fileName`

## Source
Ported from [openclaw/openclaw@905c357](https://github.com/openclaw/openclaw/commit/905c3357eb24f367f0fae568df56b0d4f88dd236)
Original author: @Kay-051