### PR TITLE
fix(feishu): harden typing indicator against rate-limits and stale replays

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -388,6 +388,7 @@ export type FeishuMessageEvent = {
     parent_id?: string;
     chat_id: string;
     chat_type: "p2p" | "group";
+    create_time?: string;
     message_type: string;
     content: string;
     mentions?: Array<{
@@ -918,6 +919,11 @@ export async function handleFeishuMessage(params: {
   }
 
   let ctx = parseFeishuMessageEvent(event, botOpenId);
+
+  // Parse message create_time (Feishu uses millisecond epoch string).
+  const messageCreateTimeMs = event.message.create_time
+    ? parseInt(event.message.create_time, 10)
+    : undefined;
 
   const messageType = event.message.message_type;
   const isForwardedInbound = isForwardedMessageType(messageType);
@@ -1472,6 +1478,7 @@ export async function handleFeishuMessage(params: {
           chatId: ctx.chatId,
           replyToMessageId,
           accountId: account.accountId,
+          messageCreateTimeMs,
         });
 
       log(`feishu[${account.accountId}]: dispatching permission error notification to agent`);
@@ -1556,6 +1563,7 @@ export async function handleFeishuMessage(params: {
       replyToMessageId,
       mentionTargets: ctx.mentionTargets,
       accountId: account.accountId,
+      messageCreateTimeMs,
     });
 
     log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -16,6 +16,24 @@ import { FeishuStreamingSession } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
+/** Maximum age (ms) for a message to receive a typing indicator reaction.
+ * Messages older than this are likely replays after context compaction (#30418). */
+const TYPING_INDICATOR_MAX_AGE_MS = 2 * 60_000;
+
+/** Minimum value to treat a timestamp as epoch-milliseconds vs epoch-seconds. */
+const MS_EPOCH_MIN = 1_000_000_000_000;
+
+/**
+ * Normalize a timestamp to epoch-milliseconds.
+ * Some Feishu payloads use epoch-seconds; values below 1e12 are treated as such.
+ */
+function normalizeEpochMs(timestamp: number | undefined): number | undefined {
+  if (!Number.isFinite(timestamp) || timestamp === undefined || timestamp <= 0) {
+    return undefined;
+  }
+  return timestamp < MS_EPOCH_MIN ? timestamp * 1000 : timestamp;
+}
+
 /** Detect if text contains markdown elements that benefit from card rendering */
 function shouldUseCard(text: string): boolean {
   return /```[\s\S]*?```/.test(text) || /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
@@ -29,11 +47,14 @@ export type CreateFeishuReplyDispatcherParams = {
   replyToMessageId?: string;
   mentionTargets?: MentionTarget[];
   accountId?: string;
+  /** Epoch ms when the inbound message was created. Used to suppress typing
+   *  indicators on old/replayed messages after context compaction (#30418). */
+  messageCreateTimeMs?: number;
 };
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
   const core = getFeishuRuntime();
-  const { cfg, agentId, chatId, replyToMessageId, mentionTargets, accountId } = params;
+  const { cfg, agentId, chatId, replyToMessageId, mentionTargets, accountId, messageCreateTimeMs } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
@@ -41,6 +62,21 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const typingCallbacks = createTypingCallbacks({
     start: async () => {
       if (!replyToMessageId) {
+        return;
+      }
+      // Skip typing indicator for old messages — likely replays after context
+      // compaction that would flood users with stale notifications (#30418).
+      const normalizedCreateTime = normalizeEpochMs(messageCreateTimeMs);
+      if (
+        normalizedCreateTime !== undefined &&
+        Date.now() - normalizedCreateTime > TYPING_INDICATOR_MAX_AGE_MS
+      ) {
+        return;
+      }
+      // Feishu reactions persist until explicitly removed, so skip keepalive
+      // re-adds when a reaction already exists. Re-adding the same emoji
+      // triggers a new push notification for every call (#28660).
+      if (typingState?.reactionId) {
         return;
       }
       typingState = await addTypingIndicator({ cfg, messageId: replyToMessageId, accountId });

--- a/src/typing.ts
+++ b/src/typing.ts
@@ -7,13 +7,94 @@ import { resolveFeishuAccount } from "./accounts.js";
 // Full list: https://github.com/go-lark/lark/blob/main/emoji.go
 const TYPING_EMOJI = "Typing"; // Typing indicator emoji
 
+/**
+ * Feishu API error codes that indicate the caller should back off.
+ * These must propagate to the typing circuit breaker so the keepalive loop
+ * can trip and stop retrying.
+ *
+ * - 99991400: Rate limit (too many requests per second)
+ * - 99991403: Monthly API call quota exceeded
+ * - 429: Standard HTTP 429 returned as a Feishu SDK error code
+ *
+ * @see https://open.feishu.cn/document/server-docs/api-call-guide/generic-error-code
+ */
+const FEISHU_BACKOFF_CODES = new Set([99991400, 99991403, 429]);
+
+/**
+ * Custom error class for Feishu backoff conditions detected from non-throwing
+ * SDK responses. Carries a numeric `.code` so that `isFeishuBackoffError()`
+ * recognises it when the error is caught downstream.
+ */
+export class FeishuBackoffError extends Error {
+  code: number;
+  constructor(code: number) {
+    super(`Feishu API backoff: code ${code}`);
+    this.name = "FeishuBackoffError";
+    this.code = code;
+  }
+}
+
+/**
+ * Check whether an error represents a rate-limit or quota-exceeded condition
+ * from the Feishu API that should stop the typing keepalive loop.
+ *
+ * Handles two shapes:
+ * 1. AxiosError with `response.status` and `response.data.code`
+ * 2. Feishu SDK error with a top-level `code` property
+ */
+export function isFeishuBackoffError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) {
+    return false;
+  }
+
+  // AxiosError shape: err.response.status / err.response.data.code
+  const response = (err as { response?: { status?: number; data?: { code?: number } } }).response;
+  if (response) {
+    if (response.status === 429) {
+      return true;
+    }
+    if (typeof response.data?.code === "number" && FEISHU_BACKOFF_CODES.has(response.data.code)) {
+      return true;
+    }
+  }
+
+  // Feishu SDK error shape: err.code
+  const code = (err as { code?: number }).code;
+  if (typeof code === "number" && FEISHU_BACKOFF_CODES.has(code)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Check whether a Feishu SDK response object contains a backoff error code.
+ *
+ * The Feishu SDK sometimes returns a normal response (no throw) with an
+ * API-level error code in the response body. This must be detected so the
+ * circuit breaker can trip.
+ */
+export function getBackoffCodeFromResponse(response: unknown): number | undefined {
+  if (typeof response !== "object" || response === null) {
+    return undefined;
+  }
+  const code = (response as { code?: number }).code;
+  if (typeof code === "number" && FEISHU_BACKOFF_CODES.has(code)) {
+    return code;
+  }
+  return undefined;
+}
+
 export type TypingIndicatorState = {
   messageId: string;
   reactionId: string | null;
 };
 
 /**
- * Add a typing indicator (reaction) to a message
+ * Add a typing indicator (reaction) to a message.
+ *
+ * Rate-limit and quota errors are re-thrown so the circuit breaker in
+ * `createTypingCallbacks` can trip and stop the keepalive loop.
  */
 export async function addTypingIndicator(params: {
   cfg: ClawdbotConfig;
@@ -36,17 +117,33 @@ export async function addTypingIndicator(params: {
       },
     });
 
+    // Feishu SDK may return a normal response with an API-level error code
+    // instead of throwing. Detect backoff codes and throw to trip the breaker.
+    const backoffCode = getBackoffCodeFromResponse(response);
+    if (backoffCode !== undefined) {
+      console.log(
+        `[feishu] typing indicator response contains backoff code ${backoffCode}, stopping keepalive`,
+      );
+      throw new FeishuBackoffError(backoffCode);
+    }
+
     const reactionId = (response as any)?.data?.reaction_id ?? null;
     return { messageId, reactionId };
   } catch (err) {
-    // Silently fail - typing indicator is not critical
+    if (isFeishuBackoffError(err)) {
+      console.log(`[feishu] typing indicator hit rate-limit/quota, stopping keepalive`);
+      throw err;
+    }
+    // Silently fail for other non-critical errors (e.g. message deleted, permission issues)
     console.log(`[feishu] failed to add typing indicator: ${err}`);
     return { messageId, reactionId: null };
   }
 }
 
 /**
- * Remove a typing indicator (reaction) from a message
+ * Remove a typing indicator (reaction) from a message.
+ *
+ * Rate-limit and quota errors are re-thrown for the same reason as above.
  */
 export async function removeTypingIndicator(params: {
   cfg: ClawdbotConfig;
@@ -62,14 +159,27 @@ export async function removeTypingIndicator(params: {
   const client = createFeishuClient(account);
 
   try {
-    await client.im.messageReaction.delete({
+    const result = await client.im.messageReaction.delete({
       path: {
         message_id: state.messageId,
         reaction_id: state.reactionId,
       },
     });
+
+    // Check for backoff codes in non-throwing SDK responses
+    const backoffCode = getBackoffCodeFromResponse(result);
+    if (backoffCode !== undefined) {
+      console.log(
+        `[feishu] typing indicator removal response contains backoff code ${backoffCode}, stopping keepalive`,
+      );
+      throw new FeishuBackoffError(backoffCode);
+    }
   } catch (err) {
-    // Silently fail - cleanup is not critical
+    if (isFeishuBackoffError(err)) {
+      console.log(`[feishu] typing indicator removal hit rate-limit/quota, stopping keepalive`);
+      throw err;
+    }
+    // Silently fail for other non-critical errors
     console.log(`[feishu] failed to remove typing indicator: ${err}`);
   }
 }


### PR DESCRIPTION
## Summary
- Fix infinite retry loop when Feishu API returns rate-limit / quota errors during typing indicator keepalive
- Skip typing indicator for messages older than 2 minutes (stale replays after context compaction)
- Prevent duplicate push notifications from keepalive re-adding an already-present reaction
- Normalize epoch-seconds vs epoch-milliseconds in message timestamps

## Key Changes

### typing.ts
- **`FeishuBackoffError`** — custom error class carrying the API error code
- **`isFeishuBackoffError(err)`** — detects rate-limit/quota errors in both AxiosError and SDK error shapes
- **`getBackoffCodeFromResponse(response)`** — detects backoff codes in non-throwing SDK responses
- `addTypingIndicator` and `removeTypingIndicator` now re-throw backoff errors so the `createTypingCallbacks` circuit breaker can trip and stop the loop; all other errors still fail silently

### reply-dispatcher.ts
- **`TYPING_INDICATOR_MAX_AGE_MS`** — 2-minute threshold for stale message detection
- **`normalizeEpochMs()`** — normalizes epoch-seconds payloads to epoch-milliseconds
- `typingCallbacks.start` skips if the inbound message is older than 2 minutes
- `typingCallbacks.start` skips if `typingState.reactionId` already exists (keepalive dedup)
- `CreateFeishuReplyDispatcherParams` gains optional `messageCreateTimeMs`

### bot.ts
- Parse `event.message.create_time` as `messageCreateTimeMs` in `handleFeishuMessage`
- Pass `messageCreateTimeMs` to both `createFeishuReplyDispatcher` call sites

## Source
Ported from upstream commits:
- [openclaw/openclaw@32ee2f0](https://github.com/openclaw/openclaw/commit/32ee2f010) — break infinite typing-indicator retry loop
- [openclaw/openclaw@7fbc40f](https://github.com/openclaw/openclaw/commit/7fbc40f82) — skip typing indicator on old messages after context compaction
- [openclaw/openclaw@02b1958](https://github.com/openclaw/openclaw/commit/02b195876) — suppress stale replay typing indicators (epoch normalization)
- [openclaw/openclaw@46df7e2](https://github.com/openclaw/openclaw/commit/46df7e242) — skip typing indicator keepalive re-adds

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 94 existing tests pass (`npx vitest run`)