### PR TITLE
fix(feishu): suppress reasoning/thinking block payloads from delivery

### DIFF
--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -141,6 +141,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         void typingCallbacks.onReplyStart?.();
       },
       deliver: async (payload: ReplyPayload, info) => {
+        // Filter out internal reasoning/thinking block chunks — these are model-internal
+        // and must not be delivered to users or leak into streaming state (#31723).
+        if (info?.kind === "block") {
+          return;
+        }
+
         const text = payload.text ?? "";
         if (!text.trim()) {
           return;
@@ -148,7 +154,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
         const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
-        if ((info?.kind === "block" || info?.kind === "final") && streamingEnabled && useCard) {
+        if (info?.kind === "final" && streamingEnabled && useCard) {
           startStreaming();
           if (streamingStartPromise) {
             await streamingStartPromise;


### PR DESCRIPTION
## Summary
- Prevent model-internal reasoning/thinking chunks from leaking to users or corrupting streaming card state
- Tighten streaming-start trigger to `final` payloads only

## Key Changes
### reply-dispatcher.ts
- Drop payloads with `info.kind === "block"` immediately at the top of `deliver()` before any processing
- Change streaming-start condition from `block || final` to `final` only

## Source
Ported from [openclaw/openclaw@477de54](https://github.com/openclaw/openclaw/commit/477de545f)