### PR TITLE
fix(feishu): Lark DM compatibility and pairing reply routing

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -387,7 +387,7 @@ export type FeishuMessageEvent = {
     root_id?: string;
     parent_id?: string;
     chat_id: string;
-    chat_type: "p2p" | "group";
+    chat_type: "p2p" | "group" | "private";
     create_time?: string;
     message_type: string;
     content: string;
@@ -1137,7 +1137,7 @@ export async function handleFeishuMessage(params: {
           try {
             await sendMessageFeishu({
               cfg,
-              to: `user:${ctx.senderOpenId}`,
+              to: `chat:${ctx.chatId}`,
               text: core.channel.pairing.buildPairingReply({
                 channel: "feishu",
                 idLine: `Your Feishu user id: ${ctx.senderOpenId}`,

--- a/src/mention.ts
+++ b/src/mention.ts
@@ -45,7 +45,7 @@ export function isMentionForwardRequest(
   const mentions = event.message.mentions ?? [];
   if (mentions.length === 0) return false;
 
-  const isDirectMessage = event.message.chat_type === "p2p";
+  const isDirectMessage = event.message.chat_type !== "group";
   const hasOtherMention = mentions.some((m) => m.id.open_id !== botOpenId);
 
   if (isDirectMessage) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export type FeishuMessageContext = {
   senderId: string;
   senderOpenId: string;
   senderName?: string;
-  chatType: "p2p" | "group";
+  chatType: "p2p" | "group" | "private";
   mentionedBot: boolean;
   hasAnyMention?: boolean;
   rootId?: string;


### PR DESCRIPTION
## Summary
- Fix Lark private chats being misidentified as group chats (Lark uses `chat_type: "private"` where Feishu uses `"p2p"`)
- Fix pairing reply going to a new conversation instead of the existing private chat in Lark

## Key Changes
### bot.ts + types.ts
- Add `"private"` to the `chat_type` union in the event type and `FeishuMessageContext`
- Pairing reply: change `to: `user:${ctx.senderOpenId}`` to `to: `chat:${ctx.chatId}`` — targets the existing conversation directly instead of opening a potentially new one

### mention.ts
- Change `isDirectMessage` check from `chat_type === "p2p"` to `chat_type !== "group"` so any non-group chat (p2p, private, or future types) is treated as a DM

## Source
Ported from:
- [openclaw/openclaw@66397c2](https://github.com/openclaw/openclaw/commit/66397c285) — restore private chat pairing replies (original author: @stakeswky)
- [openclaw/openclaw@3043e68](https://github.com/openclaw/openclaw/commit/3043e68df) — support Lark private chats as direct messages (original author: @stakeswky)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 94 existing tests pass