### PR TITLE
feat(task): implement task comment toolchain end-to-end

### DIFF
--- a/src/__tests__/tool-schema-compat.test.ts
+++ b/src/__tests__/tool-schema-compat.test.ts
@@ -99,6 +99,15 @@ function collectKeywordPaths(schema: unknown, keyword: "allOf"): string[] {
 }
 
 describe("tool schema compatibility guardrails", () => {
+  it("Given task tools, When collecting tool names, Then task comment tools are registered", () => {
+    const names = new Set(createToolCaptureApi().map((tool) => tool.name));
+    expect(names.has("feishu_task_comment_create")).toBe(true);
+    expect(names.has("feishu_task_comment_list")).toBe(true);
+    expect(names.has("feishu_task_comment_get")).toBe(true);
+    expect(names.has("feishu_task_comment_update")).toBe(true);
+    expect(names.has("feishu_task_comment_delete")).toBe(true);
+  });
+
   it("Given registered feishu tools, When checking root schema, Then no tool uses top-level allOf", () => {
     const tools = createToolCaptureApi();
     expect(tools.length).toBeGreaterThan(0);

--- a/src/task-tools/actions.ts
+++ b/src/task-tools/actions.ts
@@ -3,26 +3,33 @@ import os from "node:os";
 import path from "node:path";
 import type { TaskClient } from "./common.js";
 import {
+  TASK_COMMENT_UPDATE_FIELD_VALUES,
   TASKLIST_UPDATE_FIELD_VALUES,
   TASK_UPDATE_FIELD_VALUES,
   type AddTaskToTasklistParams,
   type AddTasklistMembersParams,
+  type CreateTaskCommentParams,
   type CreateTasklistParams,
-  CreateSubtaskParams,
-  CreateTaskParams,
-  DeleteTaskAttachmentParams,
-  GetTaskAttachmentParams,
-  GetTaskParams,
+  type CreateSubtaskParams,
+  type CreateTaskParams,
+  type DeleteTaskAttachmentParams,
+  type DeleteTaskCommentParams,
+  type GetTaskAttachmentParams,
+  type GetTaskCommentParams,
+  type GetTaskParams,
   type GetTasklistParams,
-  ListTaskAttachmentsParams,
+  type ListTaskAttachmentsParams,
+  type ListTaskCommentsParams,
   type ListTasklistsParams,
   type RemoveTaskFromTasklistParams,
   type RemoveTasklistMembersParams,
-  TaskUpdateTask,
+  type TaskCommentPatchComment,
+  type TaskUpdateTask,
   type TasklistPatchTasklist,
-  UploadTaskAttachmentParams,
+  type UploadTaskAttachmentParams,
+  type UpdateTaskCommentParams,
   type UpdateTasklistParams,
-  UpdateTaskParams,
+  type UpdateTaskParams,
 } from "./schemas.js";
 import {
   DEFAULT_TASK_ATTACHMENT_FILENAME,
@@ -36,6 +43,7 @@ import { getFeishuRuntime } from "../runtime.js";
 import { runTaskApiCall } from "./common.js";
 
 const SUPPORTED_PATCH_FIELDS = new Set<string>(TASK_UPDATE_FIELD_VALUES);
+const SUPPORTED_COMMENT_PATCH_FIELDS = new Set<string>(TASK_COMMENT_UPDATE_FIELD_VALUES);
 const SUPPORTED_TASKLIST_PATCH_FIELDS = new Set<string>(TASKLIST_UPDATE_FIELD_VALUES);
 
 function omitUndefined<T extends Record<string, unknown>>(obj: T): T {
@@ -50,10 +58,16 @@ function inferUpdateFields(task: TaskUpdateTask): string[] {
   );
 }
 
+function inferCommentUpdateFields(comment: TaskCommentPatchComment): string[] {
+  return Object.keys(comment).filter((field) =>
+    SUPPORTED_COMMENT_PATCH_FIELDS.has(field),
+  );
+}
+
 function ensureSupportedUpdateFields(
   updateFields: string[],
   supported: Set<string>,
-  resource: "task" | "tasklist",
+  resource: "task" | "comment" | "tasklist",
 ) {
   const invalid = updateFields.filter((field) => !supported.has(field));
   if (invalid.length > 0) {
@@ -99,6 +113,20 @@ function formatTasklist(tasklist: Record<string, unknown> | undefined) {
     created_at: tasklist.created_at,
     updated_at: tasklist.updated_at,
     archive_msec: tasklist.archive_msec,
+  };
+}
+
+function formatComment(comment: Record<string, unknown> | undefined) {
+  if (!comment) return undefined;
+  return {
+    id: comment.id,
+    content: comment.content,
+    creator: comment.creator,
+    reply_to_comment_id: comment.reply_to_comment_id,
+    created_at: comment.created_at,
+    updated_at: comment.updated_at,
+    resource_type: comment.resource_type,
+    resource_id: comment.resource_id,
   };
 }
 
@@ -304,6 +332,113 @@ export async function getTask(client: TaskClient, params: GetTaskParams) {
 
   return {
     task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function createTaskComment(client: TaskClient, params: CreateTaskCommentParams) {
+  const res = await runTaskApiCall("task.v2.comment.create", () =>
+    client.task.v2.comment.create({
+      data: omitUndefined({
+        content: params.content,
+        reply_to_comment_id: params.reply_to_comment_id,
+        resource_type: "task",
+        resource_id: params.task_guid,
+      }),
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    comment: formatComment((res.data?.comment ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function listTaskComments(client: TaskClient, params: ListTaskCommentsParams) {
+  const res = await runTaskApiCall("task.v2.comment.list", () =>
+    client.task.v2.comment.list({
+      params: omitUndefined({
+        resource_type: "task",
+        resource_id: params.task_guid,
+        page_size: params.page_size,
+        page_token: params.page_token,
+        direction: params.direction,
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  const items = (res.data?.items ?? []) as Record<string, unknown>[];
+
+  return {
+    items: items.map((item) => formatComment(item)),
+    page_token: res.data?.page_token,
+    has_more: res.data?.has_more,
+  };
+}
+
+export async function getTaskComment(client: TaskClient, params: GetTaskCommentParams) {
+  const res = await runTaskApiCall("task.v2.comment.get", () =>
+    client.task.v2.comment.get({
+      path: { comment_id: params.comment_id },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    comment: formatComment((res.data?.comment ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function updateTaskComment(client: TaskClient, params: UpdateTaskCommentParams) {
+  const comment = omitUndefined(params.comment as Record<string, unknown>) as TaskCommentPatchComment;
+  const updateFields = params.update_fields?.length
+    ? params.update_fields
+    : inferCommentUpdateFields(comment);
+
+  if (params.update_fields?.length) {
+    ensureSupportedUpdateFields(updateFields, SUPPORTED_COMMENT_PATCH_FIELDS, "comment");
+  }
+
+  if (Object.keys(comment).length === 0) {
+    throw new Error("comment update payload is empty");
+  }
+  if (updateFields.length === 0) {
+    throw new Error("no valid update_fields provided or inferred from comment payload");
+  }
+
+  const res = await runTaskApiCall("task.v2.comment.patch", () =>
+    client.task.v2.comment.patch({
+      path: { comment_id: params.comment_id },
+      data: {
+        comment,
+        update_fields: updateFields,
+      },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    comment: formatComment((res.data?.comment ?? undefined) as Record<string, unknown> | undefined),
+    update_fields: updateFields,
+  };
+}
+
+export async function deleteTaskComment(client: TaskClient, params: DeleteTaskCommentParams) {
+  await runTaskApiCall("task.v2.comment.delete", () =>
+    client.task.v2.comment.delete({
+      path: { comment_id: params.comment_id },
+    }),
+  );
+
+  return {
+    success: true,
+    comment_id: params.comment_id,
   };
 }
 

--- a/src/task-tools/register.ts
+++ b/src/task-tools/register.ts
@@ -6,19 +6,24 @@ import {
   addTaskToTasklist,
   addTasklistMembers,
   createSubtask,
+  createTaskComment,
   createTask,
   createTasklist,
   deleteTaskAttachment,
+  deleteTaskComment,
   deleteTask,
   deleteTasklist,
   getTaskAttachment,
+  getTaskComment,
   getTask,
   getTasklist,
+  listTaskComments,
   listTasklists,
   removeTaskFromTasklist,
   removeTasklistMembers,
   listTaskAttachments,
   uploadTaskAttachment,
+  updateTaskComment,
   updateTask,
   updateTasklist,
 } from "./actions.js";
@@ -36,26 +41,36 @@ import {
   type CreateTasklistParams,
   DeleteTaskAttachmentSchema,
   type DeleteTaskAttachmentParams,
+  DeleteTaskCommentSchema,
+  type DeleteTaskCommentParams,
   DeleteTaskSchema,
   type DeleteTaskParams,
   DeleteTasklistSchema,
   type DeleteTasklistParams,
   GetTaskAttachmentSchema,
   type GetTaskAttachmentParams,
+  GetTaskCommentSchema,
+  type GetTaskCommentParams,
   GetTaskSchema,
   type GetTaskParams,
   GetTasklistSchema,
   type GetTasklistParams,
   ListTaskAttachmentsSchema,
   type ListTaskAttachmentsParams,
+  ListTaskCommentsSchema,
+  type ListTaskCommentsParams,
   ListTasklistsSchema,
   type ListTasklistsParams,
   RemoveTaskFromTasklistSchema,
   type RemoveTaskFromTasklistParams,
   RemoveTasklistMembersSchema,
   type RemoveTasklistMembersParams,
+  CreateTaskCommentSchema,
+  type CreateTaskCommentParams,
   UploadTaskAttachmentSchema,
   type UploadTaskAttachmentParams,
+  UpdateTaskCommentSchema,
+  type UpdateTaskCommentParams,
   UpdateTaskSchema,
   UpdateTasklistSchema,
   type UpdateTaskParams,
@@ -259,5 +274,45 @@ export function registerFeishuTaskTools(api: OpenClawPluginApi) {
     run: async ({ client }, params) => updateTask(client, params),
   });
 
-  api.logger.debug?.("feishu_task: Registered task, tasklist, subtask, and attachment tools");
+  registerTaskTool<CreateTaskCommentParams>(api, {
+    name: "feishu_task_comment_create",
+    label: "Feishu Task Comment Create",
+    description: "Create a comment on a Feishu task (task v2)",
+    parameters: CreateTaskCommentSchema,
+    run: async ({ client }, params) => createTaskComment(client, params),
+  });
+
+  registerTaskTool<ListTaskCommentsParams>(api, {
+    name: "feishu_task_comment_list",
+    label: "Feishu Task Comment List",
+    description: "List comments for a Feishu task (task v2)",
+    parameters: ListTaskCommentsSchema,
+    run: async ({ client }, params) => listTaskComments(client, params),
+  });
+
+  registerTaskTool<GetTaskCommentParams>(api, {
+    name: "feishu_task_comment_get",
+    label: "Feishu Task Comment Get",
+    description: "Get a Feishu task comment by comment_id (task v2)",
+    parameters: GetTaskCommentSchema,
+    run: async ({ client }, params) => getTaskComment(client, params),
+  });
+
+  registerTaskTool<UpdateTaskCommentParams>(api, {
+    name: "feishu_task_comment_update",
+    label: "Feishu Task Comment Update",
+    description: "Update a Feishu task comment by comment_id (task v2 patch)",
+    parameters: UpdateTaskCommentSchema,
+    run: async ({ client }, params) => updateTaskComment(client, params),
+  });
+
+  registerTaskTool<DeleteTaskCommentParams>(api, {
+    name: "feishu_task_comment_delete",
+    label: "Feishu Task Comment Delete",
+    description: "Delete a Feishu task comment by comment_id (task v2)",
+    parameters: DeleteTaskCommentSchema,
+    run: async ({ client }, params) => deleteTaskComment(client, params),
+  });
+
+  api.logger.debug?.("feishu_task: Registered task, comment, tasklist, subtask, and attachment tools");
 }

--- a/src/task-tools/schemas.ts
+++ b/src/task-tools/schemas.ts
@@ -75,6 +75,7 @@ export const TASK_UPDATE_FIELD_VALUES = [
   "mode",
   "is_milestone",
 ] as const;
+export const TASK_COMMENT_UPDATE_FIELD_VALUES = ["content"] as const;
 export const TASKLIST_UPDATE_FIELD_VALUES = ["name", "owner", "archive_tasklist"] as const;
 
 export type CreateTaskParams = {
@@ -249,6 +250,10 @@ const TaskUpdateFieldSchema = Type.Union(
   TASK_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
 );
 
+const TaskCommentUpdateFieldSchema = Type.Union(
+  TASK_COMMENT_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
+);
+
 const TasklistMemberRoleSchema = Type.Union(
   [Type.Literal("owner"), Type.Literal("editor"), Type.Literal("viewer")],
   { description: "Member role (owner/editor/viewer)" },
@@ -399,9 +404,10 @@ export const UpdateTaskCommentSchema = Type.Object({
   comment_id: Type.String({ description: "Comment ID to update" }),
   comment: TaskCommentUpdateContentSchema,
   update_fields: Type.Optional(
-    Type.Array(Type.String(), {
+    Type.Array(TaskCommentUpdateFieldSchema, {
       description: "Fields to update. If omitted, this tool infers from keys in comment (content)",
       minItems: 1,
+      uniqueItems: true,
     }),
   ),
   user_id_type: Type.Optional(


### PR DESCRIPTION
## Summary
- implement task comment action chain in task tools (create/list/get/update/delete)
- register five feishu_task_comment tools in task tool registry
- constrain comment patch update_fields schema to supported literal content with unique values
- add regression test to assert task comment tools are registered

## Validation
- npx tsc --noEmit
- npx vitest run src/__tests__/tool-schema-compat.test.ts
