### PR TITLE
fix(task-tools): replace Type.Union enums with stringEnum helper to avoid anyOf in tool schemas

### DIFF
--- a/src/task-tools/schemas.ts
+++ b/src/task-tools/schemas.ts
@@ -1,6 +1,15 @@
 import { Type } from "@sinclair/typebox";
 import type { TaskClient } from "./common.js";
 
+// NOTE: Avoid Type.Union([Type.Literal(...)]) which compiles to anyOf.
+// Some providers reject anyOf in tool schemas; a flat string enum is safer.
+function stringEnum<T extends readonly string[]>(
+  values: T,
+  options: { description?: string; default?: T[number] } = {},
+) {
+  return Type.Unsafe<T[number]>({ type: "string", enum: [...values], ...options });
+}
+
 type TaskCreatePayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["create"]>[0]>;
 type TaskUpdatePayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["patch"]>[0]>;
 type TaskDeletePayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["delete"]>[0]>;
@@ -246,27 +255,19 @@ const TasklistRefSchema = Type.Object({
   section_guid: Type.Optional(Type.String({ description: "Section GUID in tasklist" })),
 });
 
-const TaskUpdateFieldSchema = Type.Union(
-  TASK_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
-);
+const TaskUpdateFieldSchema = stringEnum(TASK_UPDATE_FIELD_VALUES);
 
-const TaskCommentUpdateFieldSchema = Type.Union(
-  TASK_COMMENT_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
-);
+const TaskCommentUpdateFieldSchema = stringEnum(TASK_COMMENT_UPDATE_FIELD_VALUES);
 
-const TasklistMemberRoleSchema = Type.Union(
-  [Type.Literal("owner"), Type.Literal("editor"), Type.Literal("viewer")],
-  { description: "Member role (owner/editor/viewer)" },
-);
+const TasklistMemberRoleSchema = stringEnum(["owner", "editor", "viewer"] as const, {
+  description: "Member role (owner/editor/viewer)",
+});
 
-const TasklistUpdateFieldSchema = Type.Union(
-  TASKLIST_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
-);
+const TasklistUpdateFieldSchema = stringEnum(TASKLIST_UPDATE_FIELD_VALUES);
 
-const TasklistOriginOwnerRoleSchema = Type.Union(
-  [Type.Literal("editor"), Type.Literal("viewer"), Type.Literal("none")],
-  { description: "Role for original owner after owner transfer" },
-);
+const TasklistOriginOwnerRoleSchema = stringEnum(["editor", "viewer", "none"] as const, {
+  description: "Role for original owner after owner transfer",
+});
 
 const TasklistMemberSchema = Type.Object({
   id: Type.String({ description: "Member ID (with type controlled by user_id_type)" }),
@@ -377,9 +378,7 @@ export const ListTaskCommentsSchema = Type.Object({
   ),
   page_token: Type.Optional(Type.String({ description: "Pagination token" })),
   direction: Type.Optional(
-    Type.Union([Type.Literal("asc"), Type.Literal("desc")], {
-      description: "Sort direction",
-    }),
+    stringEnum(["asc", "desc"] as const, { description: "Sort direction" }),
   ),
   user_id_type: Type.Optional(
     Type.String({ description: "User ID type for returned creators" }),


### PR DESCRIPTION
## Summary

\`Type.Union([Type.Literal(...)])\` compiles to \`{ "anyOf": [...] }\` in JSON Schema, which some LLM API validators reject outright. Replace all occurrences in \`src/task-tools/schemas.ts\` with a local \`stringEnum\` helper that emits the standard \`{ "type": "string", "enum": [...] }\` format.

## Key Changes

- Add \`stringEnum<T>\` helper (uses \`Type.Unsafe\` internally, same pattern as \`src/agents/schema/typebox.ts\` in the upstream repo)
- Replace 6 occurrences: \`TaskUpdateFieldSchema\`, \`TaskCommentUpdateFieldSchema\`, \`TasklistMemberRoleSchema\`, \`TasklistUpdateFieldSchema\`, \`TasklistOriginOwnerRoleSchema\`, and the \`direction\` field in \`ListTaskCommentsSchema\`

## Test plan
- [x] \`npx tsc --noEmit\` passes