### PR TITLE
Fix document permission and content issues

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -9,7 +9,21 @@ import {
 import type { FeishuConfig, FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { createFeishuClient } from "./client.js";
+import { setSessionContext } from "./session-context.js";
 import { resolveFeishuAccount } from "./accounts.js";
+import fs from 'fs';
+
+const DEBUG_LOG_FILE = '/tmp/feishu_debug.log';
+
+function writeDebugLog(message: string, data?: any): void {
+  try {
+    const timestamp = new Date().toISOString();
+    const logEntry = data ? `[${timestamp}] ${message} ${JSON.stringify(data)}\n` : `[${timestamp}] ${message}\n`;
+    fs.appendFileSync(DEBUG_LOG_FILE, logEntry);
+  } catch (err) {
+    // Ignore file write errors
+  }
+}
 import {
   resolveFeishuGroupConfig,
   resolveFeishuReplyPolicy,
@@ -807,6 +821,17 @@ export async function handleFeishuMessage(params: {
           }),
       });
     }
+
+    // Store session context for tools to access
+    const sessionData = {
+      senderOpenId: ctx.senderOpenId,
+      senderId: ctx.senderId,
+      chatId: ctx.chatId,
+      chatType: isGroup ? "group" : "direct",
+    };
+    writeDebugLog(`[feishu] Setting session context`, { sessionKey: route.sessionKey, sessionData });
+    console.log(`[feishu] Setting session context for ${route.sessionKey}: senderOpenId=${ctx.senderOpenId}, chatId=${ctx.chatId}`);
+    setSessionContext(route.sessionKey, sessionData);
 
     const ctxPayload = core.channel.reply.finalizeInboundContext({
       Body: combinedBody,

--- a/src/doc-schema.ts
+++ b/src/doc-schema.ts
@@ -20,7 +20,36 @@ export const FeishuDocSchema = Type.Union([
   Type.Object({
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
+    content: Type.Optional(Type.String({
+      description: "Markdown content to write into the new document (optional, if provided will write content after creating)",
+    })),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    share_with: Type.Optional(
+      Type.Object({
+        member_type: Type.String({ description: "Member type: openid, email, userid, etc." }),
+        member_id: Type.String({ description: "Member ID (e.g., user openid)" }),
+        perm: Type.Union([Type.Literal("view"), Type.Literal("edit"), Type.Literal("full_access")], {
+          description: "Permission level: view, edit, or full_access",
+        }),
+      })
+    ),
+  }),
+  Type.Object({
+    action: Type.Literal("create_with_content"),
+    title: Type.String({ description: "Document title" }),
+    content: Type.String({
+      description: "Markdown content to write into the new document",
+    }),
+    folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    share_with: Type.Optional(
+      Type.Object({
+        member_type: Type.String({ description: "Member type: openid, email, userid, etc." }),
+        member_id: Type.String({ description: "Member ID (e.g., user openid)" }),
+        perm: Type.Union([Type.Literal("view"), Type.Literal("edit"), Type.Literal("full_access")], {
+          description: "Permission level: view, edit, or full_access",
+        }),
+      })
+    ),
   }),
   Type.Object({
     action: Type.Literal("list_blocks"),

--- a/src/docx.ts
+++ b/src/docx.ts
@@ -6,6 +6,27 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Readable } from "stream";
 import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
 import { resolveToolsConfig } from "./tools-config.js";
+import { getCurrentSenderOpenId } from "./session-context.js";
+import fs from 'fs';
+
+const DEBUG_LOG_FILE = '/tmp/feishu_debug.log';
+
+function writeDebugLog(message: string, data?: any): void {
+  try {
+    const timestamp = new Date().toISOString();
+    const logEntry = data ? `[${timestamp}] ${message} ${JSON.stringify(data)}\n` : `[${timestamp}] ${message}\n`;
+    fs.appendFileSync(DEBUG_LOG_FILE, logEntry);
+  } catch (err) {
+    // Ignore file write errors
+  }
+}
+
+// Logger for debugging
+let feishuDocLogger: OpenClawPluginApi["logger"] | undefined;
+
+export function setFeishuDocLogger(logger: OpenClawPluginApi["logger"]) {
+  feishuDocLogger = logger;
+}
 
 // ============ Helpers ============
 
@@ -243,16 +264,115 @@ async function readDoc(client: Lark.Client, docToken: string) {
   };
 }
 
-async function createDoc(client: Lark.Client, title: string, folderToken?: string) {
+async function createDoc(client: Lark.Client, title: string, folderToken?: string, shareWith?: {
+  member_type: string;
+  member_id: string;
+  perm: string;
+}, content?: string) {
+  writeDebugLog(`[feishu_doc] createDoc called`, { title, folderToken, shareWith, hasContent: !!content });
   const res = await client.docx.document.create({
     data: { title, folder_token: folderToken },
   });
   if (res.code !== 0) throw new Error(res.msg);
   const doc = res.data?.document;
+  writeDebugLog(`[feishu_doc] Document created`, { document_id: doc?.document_id, title: doc?.title });
+
+  // If no shareWith specified, try to auto-share with current user
+  let effectiveShareWith = shareWith;
+  if (!effectiveShareWith) {
+    const currentSenderOpenId = getCurrentSenderOpenId();
+    writeDebugLog(`[feishu_doc] getCurrentSenderOpenId returned`, currentSenderOpenId);
+    feishuDocLogger?.info?.(`[feishu_doc] getCurrentSenderOpenId returned:`, currentSenderOpenId);
+    if (currentSenderOpenId) {
+      effectiveShareWith = {
+        member_type: "openid",
+        member_id: currentSenderOpenId,
+        perm: "edit",
+      };
+      writeDebugLog(`[feishu_doc] Auto-sharing with current user`, currentSenderOpenId);
+      feishuDocLogger?.info?.(`[feishu_doc] Auto-sharing with current user:`, currentSenderOpenId);
+    } else {
+      writeDebugLog(`[feishu_doc] No current user found, skipping auto-share`);
+      feishuDocLogger?.warn?.(`[feishu_doc] No current user found, skipping auto-share`);
+    }
+  }
+
+  // Auto-share with specified user or current user
+  if (effectiveShareWith && doc?.document_id) {
+    try {
+      writeDebugLog(`[feishu_doc] Sharing document`, { document_id: doc.document_id, member_id: effectiveShareWith.member_id, perm: effectiveShareWith.perm });
+      feishuDocLogger?.info?.(`[feishu_doc] Sharing document ${doc.document_id} with ${effectiveShareWith.member_id} (${effectiveShareWith.perm})`);
+      await client.drive.permissionMember.create({
+        path: { token: doc.document_id },
+        params: { type: "docx", need_notification: false },
+        data: {
+          member_type: effectiveShareWith.member_type as any,
+          member_id: effectiveShareWith.member_id,
+          perm: effectiveShareWith.perm as any,
+        },
+      });
+      writeDebugLog(`[feishu_doc] Successfully shared document`);
+      feishuDocLogger?.info?.(`[feishu_doc] Successfully shared document`);
+    } catch (err) {
+      writeDebugLog(`[feishu_doc] Failed to share document`, { error: String(err) });
+      feishuDocLogger?.error?.(`Failed to share document with ${effectiveShareWith.member_id}:`, err);
+      // Don't throw - document was created successfully, just sharing failed
+    }
+  } else {
+    writeDebugLog(`[feishu_doc] No sharing performed`, { effectiveShareWith: !!effectiveShareWith, document_id: doc?.document_id });
+    feishuDocLogger?.info?.(`[feishu_doc] No sharing performed - effectiveShareWith:`, effectiveShareWith, `doc.document_id:`, doc?.document_id);
+  }
+
+  // If content is provided, write it to the document
+  let writeResult;
+  if (content && doc?.document_id) {
+    writeDebugLog(`[feishu_doc] Writing content to document`, { contentLength: content.length });
+    try {
+      writeResult = await writeDoc(client, doc.document_id, content);
+      writeDebugLog(`[feishu_doc] Content written successfully`, writeResult);
+    } catch (err) {
+      writeDebugLog(`[feishu_doc] Failed to write content`, { error: String(err) });
+      feishuDocLogger?.error?.(`Failed to write content to document:`, err);
+      // Don't throw - document was created successfully, just content write failed
+    }
+  }
+
   return {
     document_id: doc?.document_id,
     title: doc?.title,
     url: `https://feishu.cn/docx/${doc?.document_id}`,
+    ...(effectiveShareWith && { shared_with: { ...effectiveShareWith } }),
+    ...(writeResult && { content_written: writeResult }),
+  };
+}
+
+async function createDocWithContent(
+  client: Lark.Client,
+  title: string,
+  content: string,
+  folderToken?: string,
+  shareWith?: {
+    member_type: string;
+    member_id: string;
+    perm: string;
+  }
+) {
+  // Create the document first
+  const createResult = await createDoc(client, title, folderToken, shareWith);
+  const documentId = createResult.document_id;
+
+  if (!documentId) {
+    throw new Error("Failed to create document: no document_id returned");
+  }
+
+  // Write content to the document
+  const writeResult = await writeDoc(client, documentId, content);
+
+  return {
+    document_id: documentId,
+    title: createResult.title,
+    url: createResult.url,
+    content_written: writeResult,
   };
 }
 
@@ -403,7 +523,10 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   // Use first account's config for tools configuration
   const firstAccount = accounts[0];
   const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
-  
+
+  // Set logger for debugging
+  setFeishuDocLogger(api.logger);
+
   // Helper to get client for the default account
   const getClient = () => createFeishuClient(firstAccount);
   const registered: string[] = [];
@@ -415,21 +538,38 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
       name: "feishu_doc",
       label: "Feishu Doc",
       description:
-        "Feishu document operations. Actions: read, write, append, create, list_blocks, get_block, update_block, delete_block",
+        "Feishu document operations. Actions:\n" +
+        "- create: Creates a document with optional content (use content parameter to add content)\n" +
+        "- read: Reads document content and metadata\n" +
+        "- write: Replaces entire document content with markdown\n" +
+        "- append: Appends markdown content to end of document\n" +
+        "- list_blocks: Lists all blocks in the document\n" +
+        "- get_block: Gets details of a specific block\n" +
+        "- update_block: Updates text content of a specific block\n" +
+        "- delete_block: Deletes a specific block\n" +
+        "- create_with_content: Alias for 'create' with content parameter (deprecated, use 'create' with content parameter instead)",
       parameters: FeishuDocSchema,
       async execute(_toolCallId, params) {
         const p = params as FeishuDocParams;
+        writeDebugLog(`[feishu_doc] Tool execute called`, { action: p.action, params: p });
         try {
           const client = getClient();
           switch (p.action) {
             case "read":
+              writeDebugLog(`[feishu_doc] Executing read action`, { doc_token: p.doc_token });
               return json(await readDoc(client, p.doc_token));
             case "write":
+              writeDebugLog(`[feishu_doc] Executing write action`, { doc_token: p.doc_token, content_length: p.content?.length });
               return json(await writeDoc(client, p.doc_token, p.content));
             case "append":
+              writeDebugLog(`[feishu_doc] Executing append action`, { doc_token: p.doc_token, content_length: p.content?.length });
               return json(await appendDoc(client, p.doc_token, p.content));
             case "create":
-              return json(await createDoc(client, p.title, p.folder_token));
+              writeDebugLog(`[feishu_doc] Executing create action`, { title: p.title, folder_token: p.folder_token, share_with: (p as any).share_with, hasContent: !!(p as any).content });
+              return json(await createDoc(client, p.title, p.folder_token, (p as any).share_with, (p as any).content));
+            case "create_with_content":
+              writeDebugLog(`[feishu_doc] Executing create_with_content action`, { title: p.title, content_length: (p as any).content?.length, folder_token: p.folder_token, share_with: (p as any).share_with });
+              return json(await createDocWithContent(client, p.title, (p as any).content, p.folder_token, (p as any).share_with));
             case "list_blocks":
               return json(await listBlocks(client, p.doc_token));
             case "get_block":
@@ -439,9 +579,11 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
             case "delete_block":
               return json(await deleteBlock(client, p.doc_token, p.block_id));
             default:
+              writeDebugLog(`[feishu_doc] Unknown action`, { action: (p as any).action });
               return json({ error: `Unknown action: ${(p as any).action}` });
           }
         } catch (err) {
+          writeDebugLog(`[feishu_doc] Error during execution`, { error: String(err), action: p.action });
           return json({ error: err instanceof Error ? err.message : String(err) });
         }
       },

--- a/src/session-context.ts
+++ b/src/session-context.ts
@@ -1,0 +1,133 @@
+/**
+ * Session context manager for Feishu plugin.
+ * Stores current user information per session key so tools can access it.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const DEBUG_LOG_FILE = '/tmp/feishu_debug.log';
+
+function writeDebugLog(message: string, data?: any): void {
+  try {
+    const timestamp = new Date().toISOString();
+    const logEntry = data ? `[${timestamp}] ${message} ${JSON.stringify(data)}\n` : `[${timestamp}] ${message}\n`;
+    fs.appendFileSync(DEBUG_LOG_FILE, logEntry);
+  } catch (err) {
+    // Ignore file write errors
+  }
+}
+
+interface SessionContext {
+  senderOpenId?: string;
+  senderId?: string;
+  chatId?: string;
+  chatType?: "direct" | "group";
+  timestamp: number;
+}
+
+/**
+ * Session context storage.
+ * Key: sessionKey (from agent route)
+ * Value: session context with sender information
+ */
+const sessionContexts = new Map<string, SessionContext>();
+
+/**
+ * Current session key (for tool execution)
+ * This is set during message processing and accessed during tool execution
+ */
+let currentSessionKey: string | undefined;
+
+/**
+ * TTL for session context (5 minutes)
+ */
+const SESSION_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Set session context (called from message handler)
+ */
+export function setSessionContext(
+  sessionKey: string,
+  context: Omit<SessionContext, "timestamp">
+): void {
+  writeDebugLog(`[session-context] setSessionContext called`, { sessionKey, context });
+  console.log(`[session-context] Setting context for ${sessionKey}:`, context);
+  sessionContexts.set(sessionKey, {
+    ...context,
+    timestamp: Date.now(),
+  });
+
+  // Set current session key for tool execution
+  currentSessionKey = sessionKey;
+  writeDebugLog(`[session-context] currentSessionKey set to`, currentSessionKey);
+  console.log(`[session-context] Set currentSessionKey to:`, currentSessionKey);
+
+  // Clean up old entries periodically
+  cleanupOldEntries();
+}
+
+/**
+ * Get current session key
+ */
+export function getCurrentSessionKey(): string | undefined {
+  return currentSessionKey;
+}
+
+/**
+ * Get session context for a session key
+ */
+export function getSessionContext(sessionKey: string): SessionContext | undefined {
+  const context = sessionContexts.get(sessionKey);
+  if (!context) return undefined;
+
+  // Check if expired
+  if (Date.now() - context.timestamp > SESSION_TTL_MS) {
+    sessionContexts.delete(sessionKey);
+    return undefined;
+  }
+
+  return context;
+}
+
+/**
+ * Get current session context
+ */
+export function getCurrentSessionContext(): SessionContext | undefined {
+  if (!currentSessionKey) return undefined;
+  return getSessionContext(currentSessionKey);
+}
+
+/**
+ * Get current sender open ID
+ */
+export function getCurrentSenderOpenId(): string | undefined {
+  const context = getCurrentSessionContext();
+  writeDebugLog(`[session-context] getCurrentSenderOpenId called`, {
+    hasContext: !!context,
+    senderOpenId: context?.senderOpenId,
+    currentSessionKey
+  });
+  console.log(`[session-context] getCurrentSenderOpenId called, returning:`, context?.senderOpenId, `currentSessionKey:`, currentSessionKey);
+  return context?.senderOpenId;
+}
+
+/**
+ * Clean up old entries
+ */
+function cleanupOldEntries(): void {
+  const now = Date.now();
+  for (const [key, context] of sessionContexts.entries()) {
+    if (now - context.timestamp > SESSION_TTL_MS) {
+      sessionContexts.delete(key);
+    }
+  }
+}
+
+/**
+ * Clear all session contexts (for testing)
+ */
+export function clearAllSessionContexts(): void {
+  sessionContexts.clear();
+  currentSessionKey = undefined;
+}


### PR DESCRIPTION
## Problem
1. Documents created via OpenClaw cannot be edited by users - only the app can edit
2. Documents are created without content (only title)

## Root Cause
1. Document creation doesn't set user permissions
2. The `create` action doesn't accept content parameter, only creates empty docs
3. User information (senderOpenId) is available during message processing but not accessible during tool execution

## Solution
1. Add session-context.ts module to pass user info between message handler and tool execution
2. Modify bot.ts to save user info to session context when processing messages
3. Modify createDoc() in docx.ts to:
   - Auto-share document with current user (if no shareWith specified)
   - Accept optional content parameter and write it to document
4. Modify doc-schema.ts to add optional content parameter to create action

## Changes
- **new file**: src/session-context.ts - Session context management
- **modified**: src/bot.ts - Add setSessionContext call in message handler
- **modified**: src/docx.ts - Add auto-share and content parameter support
- **modified**: src/doc-schema.ts - Add content parameter to create action

## Testing
- Restart OpenClaw gateway
- Create document via Feishu message
- Verify user can edit the document
- Verify document has content (if provided)