### PR TITLE
fix(media): stop percent-encoding non-ASCII filenames in file uploads

### DIFF
--- a/src/__tests__/media.upload-filename.test.ts
+++ b/src/__tests__/media.upload-filename.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../client.js", () => ({
+  createFeishuClient: vi.fn(),
+}));
+
+import { createFeishuClient } from "../client.js";
+import { uploadFileFeishu } from "../media.js";
+
+describe("uploadFileFeishu file_name handling", () => {
+  const cfg = {
+    channels: {
+      feishu: {
+        appId: "cli_test",
+        appSecret: "sec_test",
+      },
+    },
+  } as any;
+
+  let createSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createSpy = vi.fn(async () => ({
+      code: 0,
+      file_key: "fk_test_123",
+    }));
+    vi.mocked(createFeishuClient).mockReturnValue({
+      im: { file: { create: createSpy } },
+    } as any);
+  });
+
+  it("passes ASCII filename as-is", async () => {
+    await uploadFileFeishu({
+      cfg,
+      file: Buffer.from("hello"),
+      fileName: "report.pdf",
+      fileType: "pdf",
+    });
+
+    const data = createSpy.mock.calls[0][0].data;
+    expect(data.file_name).toBe("report.pdf");
+  });
+
+  it("passes Chinese filename without percent-encoding", async () => {
+    await uploadFileFeishu({
+      cfg,
+      file: Buffer.from("hello"),
+      fileName: "测试文件1.txt",
+      fileType: "stream",
+    });
+
+    const data = createSpy.mock.calls[0][0].data;
+    expect(data.file_name).toBe("测试文件1.txt");
+    expect(data.file_name).not.toContain("%");
+  });
+
+  it("passes filename with mixed scripts without encoding", async () => {
+    const name = "プロジェクト—報告（最終版）.docx";
+    await uploadFileFeishu({
+      cfg,
+      file: Buffer.from("hello"),
+      fileName: name,
+      fileType: "doc",
+    });
+
+    const data = createSpy.mock.calls[0][0].data;
+    expect(data.file_name).toBe(name);
+    expect(data.file_name).not.toContain("%");
+  });
+});

--- a/src/media.ts
+++ b/src/media.ts
@@ -237,23 +237,6 @@ export async function uploadImageFeishu(params: {
   return { imageKey };
 }
 
-/**
- * Encode a filename for safe use in Feishu multipart/form-data uploads.
- * Non-ASCII characters (Chinese, em-dash, full-width brackets, etc.) cause
- * the upload to silently fail when passed raw through the SDK's form-data
- * serialization. RFC 5987 percent-encoding keeps headers 7-bit clean while
- * Feishu's server decodes and preserves the original display name.
- */
-export function sanitizeFileNameForUpload(fileName: string): string {
-  const ASCII_ONLY = /^[\x20-\x7E]+$/;
-  if (ASCII_ONLY.test(fileName)) {
-    return fileName;
-  }
-  return encodeURIComponent(fileName)
-    .replace(/'/g, "%27")
-    .replace(/\(/g, "%28")
-    .replace(/\)/g, "%29");
-}
 
 /**
  * Upload a file to Feishu and get a file_key for sending.
@@ -280,12 +263,10 @@ export async function uploadFileFeishu(params: {
   const fileStream =
     typeof file === "string" ? fs.createReadStream(file) : Readable.from(file);
 
-  const safeFileName = sanitizeFileNameForUpload(fileName);
-
   const response = await client.im.file.create({
     data: {
       file_type: fileType,
-      file_name: safeFileName,
+      file_name: fileName,
       file: fileStream as any,
       ...(duration !== undefined && { duration }),
     },


### PR DESCRIPTION
## Summary
- Remove `sanitizeFileNameForUpload()` which URL-encoded Chinese/non-ASCII characters in `file_name`, causing Feishu to display percent-encoded gibberish (e.g. `%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B61.txt` instead of `测试文件1.txt`)
- `file_name` is a plain multipart form text field — axios sends it as UTF-8 natively, no 7-bit encoding needed
- Add unit tests verifying ASCII, Chinese, and mixed-script filenames are passed through unchanged

Closes #379

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 109 existing tests pass
- [x] 3 new tests in `media.upload-filename.test.ts` cover ASCII / Chinese / mixed-script filenames
- [x] Manual: send a file with Chinese filename via bot, verify display name is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)