### PR TITLE
fix(media): forward agent workspace mediaLocalRoots to loadWebMedia

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -477,9 +477,10 @@ export async function sendMediaFeishu(params: {
   mediaBuffer?: Buffer;
   fileName?: string;
   replyToMessageId?: string;
+  mediaLocalRoots?: readonly string[];
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, mediaLocalRoots, accountId } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -494,30 +495,16 @@ export async function sendMediaFeishu(params: {
     buffer = mediaBuffer;
     name = fileName ?? "file";
   } else if (mediaUrl) {
-    const mediaLocalRoots = (account.config?.mediaLocalRoots ?? [])
+    const configLocalRoots = (account.config?.mediaLocalRoots ?? [])
       .map((root) => root.trim())
       .filter((root) => root.length > 0);
-    const loaded = await (async () => {
-      try {
-        return await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
-          maxBytes: mediaMaxBytes,
-          optimizeImages: false,
-        });
-      } catch (err) {
-        const shouldRetryWithCustomRoots =
-          mediaLocalRoots.length > 0 &&
-          err instanceof Error &&
-          err.message.includes("Local media path is not under an allowed directory");
-        if (!shouldRetryWithCustomRoots) {
-          throw err;
-        }
-        return await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
-          maxBytes: mediaMaxBytes,
-          optimizeImages: false,
-          localRoots: mediaLocalRoots,
-        });
-      }
-    })();
+    // Merge context-provided roots (includes agent workspace) with config roots.
+    const mergedLocalRoots = [...(mediaLocalRoots ?? []), ...configLocalRoots];
+    const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
+      maxBytes: mediaMaxBytes,
+      optimizeImages: false,
+      ...(mergedLocalRoots.length > 0 ? { localRoots: mergedLocalRoots } : {}),
+    });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";
     contentType = loaded.contentType;

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId });
@@ -21,7 +21,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     // Upload and send media if URL provided
     if (mediaUrl) {
       try {
-        const result = await sendMediaFeishu({ cfg, to, mediaUrl, accountId });
+        const result = await sendMediaFeishu({ cfg, to, mediaUrl, mediaLocalRoots, accountId });
         return { channel: "feishu", ...result };
       } catch (err) {
         // Log the error for debugging


### PR DESCRIPTION
## Summary

- Forward `mediaLocalRoots` from `ChannelOutboundContext` through `outbound.ts` → `sendMediaFeishu`, so the agent's workspace directory is included in allowed local roots
- Merge context-provided roots with config-level `mediaLocalRoots` and pass on a single `loadWebMedia` call (removes the catch-and-retry pattern)
- Fixes `LocalMediaAccessError: path-not-allowed` when agents try to send files from their own `workspace-*` directory

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Verified locally: agent can send files from its workspace directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)