### PR TITLE
fix(schema): remove union-generated anyOf/oneOf from Feishu tool schemas

### DIFF
--- a/src/__tests__/tool-schema-compat.test.ts
+++ b/src/__tests__/tool-schema-compat.test.ts
@@ -1,22 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { registerFeishuBitableTools } from "../bitable-tools/index.js";
+import { registerFeishuChatTools } from "../chat-tools/index.js";
 import { registerFeishuDocTools } from "../doc-tools/index.js";
 import { registerFeishuDriveTools } from "../drive-tools/index.js";
 import { registerFeishuPermTools } from "../perm-tools/index.js";
 import { registerFeishuTaskTools } from "../task-tools/index.js";
+import { registerFeishuUrgentTools } from "../urgent-tools/index.js";
 import { registerFeishuWikiTools } from "../wiki-tools/index.js";
 
 type RegisteredTool = {
   name: string;
   parameters: unknown;
 };
-
-const MULTI_ACTION_UNION_TOOLS = new Set([
-  "feishu_doc",
-  "feishu_wiki",
-  "feishu_drive",
-  "feishu_perm",
-]);
 
 function createToolCaptureApi() {
   const tools: RegisteredTool[] = [];
@@ -34,6 +29,8 @@ function createToolCaptureApi() {
             perm: true,
             scopes: true,
             task: true,
+            chat: true,
+            urgent: true,
           },
         },
       },
@@ -54,6 +51,8 @@ function createToolCaptureApi() {
   registerFeishuPermTools(api);
   registerFeishuBitableTools(api);
   registerFeishuTaskTools(api);
+  registerFeishuChatTools(api);
+  registerFeishuUrgentTools(api);
 
   return tools;
 }
@@ -70,7 +69,7 @@ function hasTopLevelKeyword(schema: unknown, keyword: "anyOf" | "oneOf" | "allOf
   return record ? Array.isArray(record[keyword]) : false;
 }
 
-function collectKeywordPaths(schema: unknown, keyword: "allOf"): string[] {
+function collectKeywordPaths(schema: unknown, keyword: "anyOf" | "oneOf" | "allOf"): string[] {
   const found: string[] = [];
 
   const walk = (value: unknown, path: string) => {
@@ -119,8 +118,8 @@ describe("tool schema compatibility guardrails", () => {
     expect(offenders).toEqual([]);
   });
 
-  it("Given non-union tools, When checking root schema, Then root is object without top-level anyOf/oneOf/allOf", () => {
-    const tools = createToolCaptureApi().filter((tool) => !MULTI_ACTION_UNION_TOOLS.has(tool.name));
+  it("Given all registered tools, When checking root schema, Then root is object without top-level anyOf/oneOf/allOf", () => {
+    const tools = createToolCaptureApi();
     expect(tools.length).toBeGreaterThan(0);
 
     for (const tool of tools) {
@@ -133,14 +132,16 @@ describe("tool schema compatibility guardrails", () => {
     }
   });
 
-  it("Given task tools, When checking schema tree, Then allOf is absent at any depth", () => {
-    const taskTools = createToolCaptureApi().filter(
-      (tool) => tool.name.startsWith("feishu_task") || tool.name.startsWith("feishu_tasklist"),
-    );
-    expect(taskTools.length).toBeGreaterThan(0);
+  it("Given all registered tools, When checking schema tree, Then anyOf/oneOf/allOf are absent at any depth", () => {
+    const tools = createToolCaptureApi();
+    expect(tools.length).toBeGreaterThan(0);
 
-    for (const tool of taskTools) {
+    for (const tool of tools) {
+      const anyOfPaths = collectKeywordPaths(tool.parameters, "anyOf");
+      const oneOfPaths = collectKeywordPaths(tool.parameters, "oneOf");
       const allOfPaths = collectKeywordPaths(tool.parameters, "allOf");
+      expect(anyOfPaths, `${tool.name}: anyOf paths`).toEqual([]);
+      expect(oneOfPaths, `${tool.name}: oneOf paths`).toEqual([]);
       expect(allOfPaths, `${tool.name}: allOf paths`).toEqual([]);
     }
   });

--- a/src/chat-tools/actions.ts
+++ b/src/chat-tools/actions.ts
@@ -2,6 +2,23 @@ import type { ChatClient } from "./common.js";
 import type { FeishuChatParams } from "./schemas.js";
 import { runChatApiCall } from "./common.js";
 
+type UserIdType = "open_id" | "user_id" | "union_id";
+type MemberIdType = UserIdType | "app_id";
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
+function requireStringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== "string")) {
+    throw new Error(`${field} must be a non-empty string array`);
+  }
+  return value;
+}
+
 const BLOCK_TYPE_NAMES: Record<number, string> = {
   1: "Page",
   2: "Text",
@@ -117,15 +134,35 @@ async function writeDocAnnouncement(client: ChatClient, chatId: string, content:
     }),
   );
 
-  const res = await runChatApiCall("im.chatAnnouncement.patch", () =>
-    (client as any).im.chatAnnouncement.patch({
-      path: { chat_id: chatId },
-      data: {
-        content,
-        revision: (current as any).data?.revision,
-      },
-    }),
-  );
+  const revision = (current as any).data?.revision;
+  if (!revision) {
+    throw new Error("Failed to load current announcement revision");
+  }
+
+  let res: unknown;
+  try {
+    // Prefer SDK current payload shape (revision + requests[]).
+    res = await runChatApiCall("im.chatAnnouncement.patch", () =>
+      (client as any).im.chatAnnouncement.patch({
+        path: { chat_id: chatId },
+        data: {
+          revision,
+          requests: [content],
+        },
+      }),
+    );
+  } catch {
+    // Backward compatibility for tenants still accepting legacy content payload.
+    res = await runChatApiCall("im.chatAnnouncement.patch", () =>
+      (client as any).im.chatAnnouncement.patch({
+        path: { chat_id: chatId },
+        data: {
+          content,
+          revision,
+        },
+      }),
+    );
+  }
 
   return {
     success: true,
@@ -210,7 +247,13 @@ async function batchUpdateAnnouncementBlocks(
 
 // ============== New Chat Management Functions ==============
 
-async function createChat(client: ChatClient, name: string, userIds?: string[], description?: string) {
+async function createChat(
+  client: ChatClient,
+  name: string,
+  userIds?: string[],
+  description?: string,
+  userIdType: UserIdType = "open_id",
+) {
   const data: any = { name };
   if (userIds && userIds.length > 0) {
     data.user_id_list = userIds;
@@ -222,7 +265,7 @@ async function createChat(client: ChatClient, name: string, userIds?: string[], 
   const res = await runChatApiCall("im.chat.create", () =>
     (client as any).im.chat.create({
       data,
-      params: { user_id_type: "open_id" },
+      params: { user_id_type: userIdType },
     }),
   );
 
@@ -233,11 +276,16 @@ async function createChat(client: ChatClient, name: string, userIds?: string[], 
   };
 }
 
-async function addMembers(client: ChatClient, chatId: string, userIds: string[]) {
+async function addMembers(
+  client: ChatClient,
+  chatId: string,
+  userIds: string[],
+  memberIdType: MemberIdType = "open_id",
+) {
   const res = await runChatApiCall("im.chatMembers.create", () =>
     (client as any).im.chatMembers.create({
       path: { chat_id: chatId },
-      params: { member_id_type: "open_id" },
+      params: { member_id_type: memberIdType },
       data: { id_list: userIds },
     }),
   );
@@ -300,9 +348,10 @@ async function createSessionChat(
   userIds: string[],
   greeting?: string,
   description?: string,
+  userIdType: UserIdType = "open_id",
 ) {
   // Step 1: Create the chat
-  const createResult = await createChat(client, name, userIds, description);
+  const createResult = await createChat(client, name, userIds, description, userIdType);
   const chatId = createResult.chat_id;
   
   if (!chatId) {
@@ -358,15 +407,21 @@ export async function runChatAction(client: ChatClient, params: FeishuChatParams
   switch (params.action) {
     case "get_announcement_info":
     case "get_announcement":
-      return getAnnouncement(client, params.chat_id);
+      return getAnnouncement(client, requireString(params.chat_id, "chat_id"));
     case "list_announcement_blocks":
-      return listAnnouncementBlocks(client, params.chat_id);
+      return listAnnouncementBlocks(client, requireString(params.chat_id, "chat_id"));
     case "get_announcement_block":
-      return getAnnouncementBlock(client, params.chat_id, params.block_id);
+      return getAnnouncementBlock(
+        client,
+        requireString(params.chat_id, "chat_id"),
+        requireString(params.block_id, "block_id"),
+      );
     case "write_announcement": {
-      const current = await getAnnouncement(client, params.chat_id);
+      const chatId = requireString(params.chat_id, "chat_id");
+      const content = requireString(params.content, "content");
+      const current = await getAnnouncement(client, chatId);
       if (current.announcement_type === "doc") {
-        return writeDocAnnouncement(client, params.chat_id, params.content);
+        return writeDocAnnouncement(client, chatId, content);
       } else {
         // For docx announcements, append a text block under the Page root block.
         // Full replacement is not supported via API; use update_announcement_block to edit existing blocks.
@@ -375,15 +430,17 @@ export async function runChatAction(client: ChatClient, params: FeishuChatParams
         if (!pageBlock?.block_id) {
           return { error: "Could not find the Page root block for docx announcement. Use list_announcement_blocks to inspect the structure." };
         }
-        return createTextBlock(client, params.chat_id, pageBlock.block_id, params.content);
+        return createTextBlock(client, chatId, pageBlock.block_id, content);
       }
     }
     case "append_announcement": {
-      const current = await getAnnouncement(client, params.chat_id);
+      const chatId = requireString(params.chat_id, "chat_id");
+      const content = requireString(params.content, "content");
+      const current = await getAnnouncement(client, chatId);
       if (current.announcement_type === "doc") {
         const existingContent = (current as any).content || "";
-        const newContent = existingContent + "\n" + params.content;
-        return writeDocAnnouncement(client, params.chat_id, newContent);
+        const newContent = existingContent + "\n" + content;
+        return writeDocAnnouncement(client, chatId, newContent);
       } else {
         // For docx format, the parent block must be the Page root block (block_type: 1)
         const blocks: any[] = (current as any).blocks ?? [];
@@ -391,40 +448,52 @@ export async function runChatAction(client: ChatClient, params: FeishuChatParams
         if (!pageBlock?.block_id) {
           return { error: "Could not find the Page root block for docx announcement. Use list_announcement_blocks to inspect the structure." };
         }
-        return createTextBlock(client, params.chat_id, pageBlock.block_id, params.content);
+        return createTextBlock(client, chatId, pageBlock.block_id, content);
       }
     }
     case "update_announcement_block": {
       const requests = [
         {
-          block_id: params.block_id,
+          block_id: requireString(params.block_id, "block_id"),
           update_text_elements: {
-            elements: [{ text_run: { content: params.content } }],
+            elements: [{ text_run: { content: requireString(params.content, "content") } }],
           },
         },
       ];
-      return batchUpdateAnnouncementBlocks(client, params.chat_id, requests);
+      return batchUpdateAnnouncementBlocks(client, requireString(params.chat_id, "chat_id"), requests);
     }
     // ============== New Chat Management Actions ==============
     case "create_chat": {
-      return createChat(client, params.name, params.user_ids, params.description);
+      return createChat(
+        client,
+        requireString(params.name, "name"),
+        params.user_ids,
+        params.description,
+        params.user_id_type,
+      );
     }
     case "add_members": {
-      return addMembers(client, params.chat_id, params.user_ids);
+      return addMembers(
+        client,
+        requireString(params.chat_id, "chat_id"),
+        requireStringArray(params.user_ids, "user_ids"),
+        params.member_id_type,
+      );
     }
     case "check_bot_in_chat": {
-      return checkBotInChat(client, params.chat_id);
+      return checkBotInChat(client, requireString(params.chat_id, "chat_id"));
     }
     case "delete_chat": {
-      return deleteChat(client, params.chat_id);
+      return deleteChat(client, requireString(params.chat_id, "chat_id"));
     }
     case "create_session_chat": {
       return createSessionChat(
         client,
-        params.name,
-        params.user_ids,
+        requireString(params.name, "name"),
+        requireStringArray(params.user_ids, "user_ids"),
         params.greeting,
         params.description,
+        params.user_id_type,
       );
     }
     default:

--- a/src/chat-tools/schemas.ts
+++ b/src/chat-tools/schemas.ts
@@ -1,66 +1,61 @@
 import { Type, type Static } from "@sinclair/typebox";
 
-export const FeishuChatSchema = Type.Union([
-  Type.Object({
-    action: Type.Literal("get_announcement_info"),
-    chat_id: Type.String({ description: "Chat ID to get announcement from" }),
-  }),
-  Type.Object({
-    action: Type.Literal("get_announcement"),
-    chat_id: Type.String({ description: "Chat ID to get announcement from" }),
-  }),
-  Type.Object({
-    action: Type.Literal("write_announcement"),
-    chat_id: Type.String({ description: "Chat ID to write announcement to" }),
-    content: Type.String({ description: "Content to write. For doc format: replaces the entire announcement. For docx format: appends a new text block under the page root." }),
-  }),
-  Type.Object({
-    action: Type.Literal("append_announcement"),
-    chat_id: Type.String({ description: "Chat ID to append announcement to" }),
-    content: Type.String({ description: "Markdown content to append to announcement" }),
-  }),
-  Type.Object({
-    action: Type.Literal("list_announcement_blocks"),
-    chat_id: Type.String({ description: "Chat ID to list announcement blocks from" }),
-  }),
-  Type.Object({
-    action: Type.Literal("get_announcement_block"),
-    chat_id: Type.String({ description: "Chat ID to get announcement block from" }),
-    block_id: Type.String({ description: "Block ID (from list_announcement_blocks)" }),
-  }),
-  Type.Object({
-    action: Type.Literal("update_announcement_block"),
-    chat_id: Type.String({ description: "Chat ID to update announcement block in" }),
-    block_id: Type.String({ description: "Block ID (from list_announcement_blocks)" }),
-    content: Type.String({ description: "New text content" }),
-  }),
-  // ============== New Chat Management Actions ==============
-  Type.Object({
-    action: Type.Literal("create_chat"),
-    name: Type.String({ description: "Group chat name" }),
-    user_ids: Type.Optional(Type.Array(Type.String(), { description: "List of user IDs to add to the group" })),
-    description: Type.Optional(Type.String({ description: "Group chat description" })),
-  }),
-  Type.Object({
-    action: Type.Literal("add_members"),
-    chat_id: Type.String({ description: "Chat ID to add members to" }),
-    user_ids: Type.Array(Type.String(), { description: "List of user IDs to add" }),
-  }),
-  Type.Object({
-    action: Type.Literal("check_bot_in_chat"),
-    chat_id: Type.String({ description: "Chat ID to check" }),
-  }),
-  Type.Object({
-    action: Type.Literal("delete_chat"),
-    chat_id: Type.String({ description: "Chat ID to delete/dismiss" }),
-  }),
-  Type.Object({
-    action: Type.Literal("create_session_chat"),
-    name: Type.String({ description: "Session group name" }),
-    user_ids: Type.Array(Type.String(), { description: "List of user IDs to invite" }),
-    greeting: Type.Optional(Type.String({ description: "Greeting message to send (default: Hello! I've created this group chat for us to collaborate.)" })),
-    description: Type.Optional(Type.String({ description: "Group description" })),
-  }),
-]);
+function stringEnum<T extends readonly string[]>(
+  values: T,
+  options: { description?: string; default?: T[number] } = {},
+) {
+  return Type.Unsafe<T[number]>({ type: "string", enum: [...values], ...options });
+}
+
+const CHAT_ACTION_VALUES = [
+  "get_announcement_info",
+  "get_announcement",
+  "write_announcement",
+  "append_announcement",
+  "list_announcement_blocks",
+  "get_announcement_block",
+  "update_announcement_block",
+  "create_chat",
+  "add_members",
+  "check_bot_in_chat",
+  "delete_chat",
+  "create_session_chat",
+] as const;
+
+const USER_ID_TYPE_VALUES = ["open_id", "user_id", "union_id"] as const;
+const MEMBER_ID_TYPE_VALUES = ["open_id", "user_id", "union_id", "app_id"] as const;
+
+export const FeishuChatSchema = Type.Object({
+  action: stringEnum(CHAT_ACTION_VALUES, { description: "Chat action" }),
+  chat_id: Type.Optional(Type.String({ description: "Chat ID" })),
+  content: Type.Optional(Type.String({ description: "Announcement content / block content" })),
+  block_id: Type.Optional(Type.String({ description: "Announcement block ID" })),
+
+  name: Type.Optional(Type.String({ description: "Group chat name" })),
+  user_ids: Type.Optional(
+    Type.Array(Type.String(), {
+      description: "User/member IDs used by create_chat/add_members/create_session_chat",
+    }),
+  ),
+  user_id_type: Type.Optional(
+    stringEnum(USER_ID_TYPE_VALUES, {
+      description: "ID type for user_ids in create_chat/create_session_chat",
+      default: "open_id",
+    }),
+  ),
+  member_id_type: Type.Optional(
+    stringEnum(MEMBER_ID_TYPE_VALUES, {
+      description: "ID type for add_members (supports app_id for bots)",
+      default: "open_id",
+    }),
+  ),
+  greeting: Type.Optional(
+    Type.String({
+      description:
+        "Greeting message for create_session_chat (default: Hello! I've created this group chat for us to collaborate.)",
+    }),
+  ),
+  description: Type.Optional(Type.String({ description: "Group chat description" })),
+});
 
 export type FeishuChatParams = Static<typeof FeishuChatSchema>;

--- a/src/doc-tools/actions.ts
+++ b/src/doc-tools/actions.ts
@@ -44,6 +44,13 @@ function normalizePageSize(pageSize?: number) {
   return pageSize;
 }
 
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
 function omitUndefined<T extends Record<string, unknown>>(obj: T): T {
   return Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined)) as T;
 }
@@ -304,37 +311,79 @@ export async function runDocAction(
 ) {
   switch (params.action) {
     case "read":
-      return readDoc(client, params.doc_token);
+      return readDoc(client, requireString(params.doc_token, "doc_token"));
     case "write":
-      return writeDoc(client, params.doc_token, params.content, mediaMaxBytes);
+      return writeDoc(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        requireString(params.content, "content"),
+        mediaMaxBytes,
+      );
     case "append":
-      return appendDoc(client, params.doc_token, params.content, mediaMaxBytes);
+      return appendDoc(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        requireString(params.content, "content"),
+        mediaMaxBytes,
+      );
     case "create":
-      return createDoc(client, params.title, params.folder_token);
+      return createDoc(client, requireString(params.title, "title"), params.folder_token);
     case "create_and_write":
       return createAndWriteDoc(
         client,
-        params.title,
-        params.content,
+        requireString(params.title, "title"),
+        requireString(params.content, "content"),
         mediaMaxBytes,
         params.folder_token,
       );
     case "list_blocks":
-      return listBlocks(client, params.doc_token);
+      return listBlocks(client, requireString(params.doc_token, "doc_token"));
     case "get_block":
-      return getBlock(client, params.doc_token, params.block_id);
+      return getBlock(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        requireString(params.block_id, "block_id"),
+      );
     case "update_block":
-      return updateBlock(client, params.doc_token, params.block_id, params.content);
+      return updateBlock(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        requireString(params.block_id, "block_id"),
+        requireString(params.content, "content"),
+      );
     case "delete_block":
-      return deleteBlock(client, params.doc_token, params.block_id);
+      return deleteBlock(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        requireString(params.block_id, "block_id"),
+      );
     case "list_comments":
-      return listComments(client, params.doc_token, params.page_token, params.page_size);
+      return listComments(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        params.page_token,
+        params.page_size,
+      );
     case "create_comment":
-      return createComment(client, params.doc_token, params.content);
+      return createComment(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        requireString(params.content, "content"),
+      );
     case "get_comment":
-      return getComment(client, params.doc_token, params.comment_id);
+      return getComment(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        requireString(params.comment_id, "comment_id"),
+      );
     case "list_comment_replies":
-      return listCommentReplies(client, params.doc_token, params.comment_id, params.page_token, params.page_size);
+      return listCommentReplies(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        requireString(params.comment_id, "comment_id"),
+        params.page_token,
+        params.page_size,
+      );
     default:
       return { error: `Unknown action: ${(params as any).action}` };
   }

--- a/src/doc-tools/schemas.ts
+++ b/src/doc-tools/schemas.ts
@@ -1,85 +1,49 @@
 import { Type, type Static } from "@sinclair/typebox";
 
-export const FeishuDocSchema = Type.Union([
-  Type.Object({
-    action: Type.Literal("read"),
-    doc_token: Type.String({
+function stringEnum<T extends readonly string[]>(
+  values: T,
+  options: { description?: string; default?: T[number] } = {},
+) {
+  return Type.Unsafe<T[number]>({ type: "string", enum: [...values], ...options });
+}
+
+const DOC_ACTION_VALUES = [
+  "read",
+  "write",
+  "append",
+  "create",
+  "create_and_write",
+  "list_blocks",
+  "get_block",
+  "update_block",
+  "delete_block",
+  "list_comments",
+  "create_comment",
+  "get_comment",
+  "list_comment_replies",
+] as const;
+
+export const FeishuDocSchema = Type.Object({
+  action: stringEnum(DOC_ACTION_VALUES, { description: "Document action" }),
+  doc_token: Type.Optional(
+    Type.String({
       description:
         "Document token (extract from URL /docx/XXX or /docs/XXX). Supports both new (docx) and legacy (doc) formats.",
     }),
-  }),
-  Type.Object({
-    action: Type.Literal("write"),
-    doc_token: Type.String({ description: "Document token" }),
-    content: Type.String({
-      description: "Markdown content to write (replaces entire document content)",
+  ),
+  content: Type.Optional(
+    Type.String({
+      description: "Markdown content for write/append/comment/update operations",
     }),
-  }),
-  Type.Object({
-    action: Type.Literal("append"),
-    doc_token: Type.String({ description: "Document token" }),
-    content: Type.String({ description: "Markdown content to append to end of document" }),
-  }),
-  Type.Object({
-    action: Type.Literal("create"),
-    title: Type.String({ description: "Document title" }),
-    folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
-  }),
-  Type.Object({
-    action: Type.Literal("create_and_write"),
-    title: Type.String({ description: "Document title" }),
-    content: Type.String({
-      description: "Markdown content to write immediately after document creation",
-    }),
-    folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
-  }),
-  Type.Object({
-    action: Type.Literal("list_blocks"),
-    doc_token: Type.String({ description: "Document token" }),
-  }),
-  Type.Object({
-    action: Type.Literal("get_block"),
-    doc_token: Type.String({ description: "Document token" }),
-    block_id: Type.String({ description: "Block ID (from list_blocks)" }),
-  }),
-  Type.Object({
-    action: Type.Literal("update_block"),
-    doc_token: Type.String({ description: "Document token" }),
-    block_id: Type.String({ description: "Block ID (from list_blocks)" }),
-    content: Type.String({ description: "New text content" }),
-  }),
-  Type.Object({
-    action: Type.Literal("delete_block"),
-    doc_token: Type.String({ description: "Document token" }),
-    block_id: Type.String({ description: "Block ID" }),
-  }),
-  Type.Object({
-    action: Type.Literal("list_comments"),
-    doc_token: Type.String({ description: "Document token" }),
-    page_token: Type.Optional(Type.String({ description: "Page token for pagination" })),
-    page_size: Type.Optional(
-      Type.Integer({ minimum: 1, description: "Page size, default 50 (positive integer)" }),
-    ),
-  }),
-  Type.Object({
-    action: Type.Literal("create_comment"),
-    doc_token: Type.String({ description: "Document token" }),
-    content: Type.String({ description: "Comment content" }),
-  }),
-  Type.Object({
-    action: Type.Literal("get_comment"),
-    doc_token: Type.String({ description: "Document token" }),
-    comment_id: Type.String({ description: "Comment ID" }),
-  }),
-  Type.Object({
-    action: Type.Literal("list_comment_replies"),
-    doc_token: Type.String({ description: "Document token" }),
-    comment_id: Type.String({ description: "Comment ID" }),
-    page_token: Type.Optional(Type.String({ description: "Page token for pagination" })),
-    page_size: Type.Optional(
-      Type.Integer({ minimum: 1, description: "Page size, default 50 (positive integer)" }),
-    ),
-  }),
-]);
+  ),
+  title: Type.Optional(Type.String({ description: "Document title (for create/create_and_write)" })),
+  folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+  block_id: Type.Optional(Type.String({ description: "Block ID (from list_blocks)" })),
+  comment_id: Type.Optional(Type.String({ description: "Comment ID" })),
+  page_token: Type.Optional(Type.String({ description: "Page token for pagination" })),
+  page_size: Type.Optional(
+    Type.Integer({ minimum: 1, description: "Page size, default 50 (positive integer)" }),
+  ),
+});
 
 export type FeishuDocParams = Static<typeof FeishuDocSchema>;

--- a/src/drive-tools/actions.ts
+++ b/src/drive-tools/actions.ts
@@ -5,6 +5,13 @@ import type { FeishuDriveParams } from "./schemas.js";
 type DriveMoveType = "doc" | "docx" | "sheet" | "bitable" | "folder" | "file" | "mindnote" | "slides";
 type DriveDeleteType = DriveMoveType | "shortcut";
 
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
 async function getFileType(client: DriveClient, fileToken: string): Promise<string> {
   let pageToken: string | undefined;
   
@@ -196,18 +203,23 @@ export async function runDriveAction(
     case "list":
       return listFolder(client, params.folder_token);
     case "info":
-      return getFileInfo(client, params.file_token);
+      return getFileInfo(client, requireString(params.file_token, "file_token"));
     case "create_folder":
-      return createFolder(client, params.name, params.folder_token);
+      return createFolder(client, requireString(params.name, "name"), params.folder_token);
     case "move":
-      return moveFile(client, params.file_token, params.type, params.folder_token);
+      return moveFile(
+        client,
+        requireString(params.file_token, "file_token"),
+        requireString(params.type, "type"),
+        requireString(params.folder_token, "folder_token"),
+      );
     case "delete":
-      return deleteFile(client, params.file_token, params.type);
+      return deleteFile(client, requireString(params.file_token, "file_token"), params.type);
     case "import_document":
       return importDocument(
         client,
-        params.title,
-        params.content,
+        requireString(params.title, "title"),
+        requireString(params.content, "content"),
         mediaMaxBytes,
         params.folder_token,
         params.doc_type || "docx",

--- a/src/drive-tools/schemas.ts
+++ b/src/drive-tools/schemas.ts
@@ -1,67 +1,54 @@
 import { Type, type Static } from "@sinclair/typebox";
 
-const FileType = Type.Union([
-  Type.Literal("doc"),
-  Type.Literal("docx"),
-  Type.Literal("sheet"),
-  Type.Literal("bitable"),
-  Type.Literal("folder"),
-  Type.Literal("file"),
-  Type.Literal("mindnote"),
-  Type.Literal("shortcut"),
-]);
+function stringEnum<T extends readonly string[]>(
+  values: T,
+  options: { description?: string; default?: T[number] } = {},
+) {
+  return Type.Unsafe<T[number]>({ type: "string", enum: [...values], ...options });
+}
 
-const DocType = Type.Union([
-  Type.Literal("docx", { description: "New generation document (default)" }),
-  Type.Literal("doc", { description: "Legacy document" }),
-]);
+const FILE_TYPE_VALUES = [
+  "doc",
+  "docx",
+  "sheet",
+  "bitable",
+  "folder",
+  "file",
+  "mindnote",
+  "shortcut",
+] as const;
 
-export const FeishuDriveSchema = Type.Union([
-  Type.Object({
-    action: Type.Literal("list"),
-    folder_token: Type.Optional(
-      Type.String({ description: "Folder token (optional, omit for root directory)" }),
-    ),
-  }),
-  Type.Object({
-    action: Type.Literal("info"),
-    file_token: Type.String({ description: "File or folder token" }),
-    type: Type.Optional(FileType),
-  }),
-  Type.Object({
-    action: Type.Literal("create_folder"),
-    name: Type.String({ description: "Folder name" }),
-    folder_token: Type.Optional(
-      Type.String({ description: "Parent folder token (optional, omit for root)" }),
-    ),
-  }),
-  Type.Object({
-    action: Type.Literal("move"),
-    file_token: Type.String({ description: "File token to move" }),
-    type: FileType,
-    folder_token: Type.String({ description: "Target folder token" }),
-  }),
-  Type.Object({
-    action: Type.Literal("delete"),
-    file_token: Type.String({ description: "File token to delete" }),
-    type: Type.Optional(FileType),
-  }),
-  Type.Object({
-    action: Type.Literal("import_document"),
-    title: Type.String({
-      description: "Document title",
-    }),
-    content: Type.String({
+const DOC_TYPE_VALUES = ["docx", "doc"] as const;
+
+const DRIVE_ACTION_VALUES = [
+  "list",
+  "info",
+  "create_folder",
+  "move",
+  "delete",
+  "import_document",
+] as const;
+
+export const FeishuDriveSchema = Type.Object({
+  action: stringEnum(DRIVE_ACTION_VALUES, { description: "Drive action" }),
+  folder_token: Type.Optional(
+    Type.String({ description: "Folder token (optional, omit for root directory)" }),
+  ),
+  file_token: Type.Optional(Type.String({ description: "File or folder token" })),
+  type: Type.Optional(stringEnum(FILE_TYPE_VALUES, { description: "File type" })),
+  name: Type.Optional(Type.String({ description: "Folder name (for create_folder)" })),
+  title: Type.Optional(Type.String({ description: "Document title (for import_document)" })),
+  content: Type.Optional(
+    Type.String({
       description:
         "Markdown content to import. Supports full Markdown syntax including tables, lists, code blocks, etc.",
     }),
-    folder_token: Type.Optional(
-      Type.String({
-        description: "Target folder token (optional, defaults to root). Use 'list' to find folder tokens.",
-      }),
-    ),
-    doc_type: Type.Optional(DocType),
-  }),
-]);
+  ),
+  doc_type: Type.Optional(
+    stringEnum(DOC_TYPE_VALUES, {
+      description: "Document type for import_document (docx default, doc legacy)",
+    }),
+  ),
+});
 
 export type FeishuDriveParams = Static<typeof FeishuDriveSchema>;

--- a/src/perm-tools/actions.ts
+++ b/src/perm-tools/actions.ts
@@ -33,6 +33,13 @@ type MemberType =
   | "wikispaceid";
 type PermType = "view" | "edit" | "full_access";
 
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
 async function listMembers(client: PermClient, token: string, type: string) {
   const res = await runPermApiCall("drive.permissionMember.list", () =>
     client.drive.permissionMember.list({
@@ -100,11 +107,28 @@ async function removeMember(
 export async function runPermAction(client: PermClient, params: FeishuPermParams) {
   switch (params.action) {
     case "list":
-      return listMembers(client, params.token, params.type);
+      return listMembers(
+        client,
+        requireString(params.token, "token"),
+        requireString(params.type, "type"),
+      );
     case "add":
-      return addMember(client, params.token, params.type, params.member_type, params.member_id, params.perm);
+      return addMember(
+        client,
+        requireString(params.token, "token"),
+        requireString(params.type, "type"),
+        requireString(params.member_type, "member_type"),
+        requireString(params.member_id, "member_id"),
+        requireString(params.perm, "perm"),
+      );
     case "remove":
-      return removeMember(client, params.token, params.type, params.member_type, params.member_id);
+      return removeMember(
+        client,
+        requireString(params.token, "token"),
+        requireString(params.type, "type"),
+        requireString(params.member_type, "member_type"),
+        requireString(params.member_id, "member_id"),
+      );
     default:
       return { error: `Unknown action: ${(params as any).action}` };
   }

--- a/src/perm-tools/schemas.ts
+++ b/src/perm-tools/schemas.ts
@@ -1,52 +1,46 @@
 import { Type, type Static } from "@sinclair/typebox";
 
-const TokenType = Type.Union([
-  Type.Literal("doc"),
-  Type.Literal("docx"),
-  Type.Literal("sheet"),
-  Type.Literal("bitable"),
-  Type.Literal("folder"),
-  Type.Literal("file"),
-  Type.Literal("wiki"),
-  Type.Literal("mindnote"),
-]);
+function stringEnum<T extends readonly string[]>(
+  values: T,
+  options: { description?: string; default?: T[number] } = {},
+) {
+  return Type.Unsafe<T[number]>({ type: "string", enum: [...values], ...options });
+}
 
-const MemberType = Type.Union([
-  Type.Literal("email"),
-  Type.Literal("openid"),
-  Type.Literal("userid"),
-  Type.Literal("unionid"),
-  Type.Literal("openchat"),
-  Type.Literal("opendepartmentid"),
-]);
+const TOKEN_TYPE_VALUES = [
+  "doc",
+  "docx",
+  "sheet",
+  "bitable",
+  "folder",
+  "file",
+  "wiki",
+  "mindnote",
+] as const;
 
-const Permission = Type.Union([
-  Type.Literal("view"),
-  Type.Literal("edit"),
-  Type.Literal("full_access"),
-]);
+const MEMBER_TYPE_VALUES = [
+  "email",
+  "openid",
+  "userid",
+  "unionid",
+  "openchat",
+  "opendepartmentid",
+] as const;
 
-export const FeishuPermSchema = Type.Union([
-  Type.Object({
-    action: Type.Literal("list"),
-    token: Type.String({ description: "File token" }),
-    type: TokenType,
-  }),
-  Type.Object({
-    action: Type.Literal("add"),
-    token: Type.String({ description: "File token" }),
-    type: TokenType,
-    member_type: MemberType,
-    member_id: Type.String({ description: "Member ID (email, open_id, user_id, etc.)" }),
-    perm: Permission,
-  }),
-  Type.Object({
-    action: Type.Literal("remove"),
-    token: Type.String({ description: "File token" }),
-    type: TokenType,
-    member_type: MemberType,
-    member_id: Type.String({ description: "Member ID to remove" }),
-  }),
-]);
+const PERMISSION_VALUES = ["view", "edit", "full_access"] as const;
+const PERM_ACTION_VALUES = ["list", "add", "remove"] as const;
+
+export const FeishuPermSchema = Type.Object({
+  action: stringEnum(PERM_ACTION_VALUES, { description: "Permission action" }),
+  token: Type.Optional(Type.String({ description: "File token" })),
+  type: Type.Optional(stringEnum(TOKEN_TYPE_VALUES, { description: "File token type" })),
+  member_type: Type.Optional(
+    stringEnum(MEMBER_TYPE_VALUES, {
+      description: "Member ID type (email/openid/userid/unionid/openchat/opendepartmentid)",
+    }),
+  ),
+  member_id: Type.Optional(Type.String({ description: "Member ID" })),
+  perm: Type.Optional(stringEnum(PERMISSION_VALUES, { description: "Permission level" })),
+});
 
 export type FeishuPermParams = Static<typeof FeishuPermSchema>;

--- a/src/wiki-tools/actions.ts
+++ b/src/wiki-tools/actions.ts
@@ -7,6 +7,13 @@ const WIKI_ACCESS_HINT =
   "To grant wiki access: Open wiki space -> Settings -> Members -> Add the bot. " +
   "See: https://open.feishu.cn/document/server-docs/docs/wiki-v2/wiki-qa#a40ad4ca";
 
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
 async function listSpaces(client: WikiClient) {
   const res = await runWikiApiCall("wiki.space.list", () => client.wiki.space.list({}));
   const spaces =
@@ -140,26 +147,37 @@ export async function runWikiAction(client: WikiClient, params: FeishuWikiParams
     case "spaces":
       return listSpaces(client);
     case "nodes":
-      return listNodes(client, params.space_id, params.parent_node_token);
+      return listNodes(client, requireString(params.space_id, "space_id"), params.parent_node_token);
     case "get":
-      return getNode(client, params.token);
+      return getNode(client, requireString(params.token, "token"));
     case "search":
       return {
         error:
           "Search is not available. Use feishu_wiki with action: 'nodes' to browse or action: 'get' to lookup by token.",
       };
     case "create":
-      return createNode(client, params.space_id, params.title, params.obj_type, params.parent_node_token);
+      return createNode(
+        client,
+        requireString(params.space_id, "space_id"),
+        requireString(params.title, "title"),
+        params.obj_type,
+        params.parent_node_token,
+      );
     case "move":
       return moveNode(
         client,
-        params.space_id,
-        params.node_token,
+        requireString(params.space_id, "space_id"),
+        requireString(params.node_token, "node_token"),
         params.target_space_id,
         params.target_parent_token,
       );
     case "rename":
-      return renameNode(client, params.space_id, params.node_token, params.title);
+      return renameNode(
+        client,
+        requireString(params.space_id, "space_id"),
+        requireString(params.node_token, "node_token"),
+        requireString(params.title, "title"),
+      );
     default:
       return { error: `Unknown action: ${(params as any).action}` };
   }

--- a/src/wiki-tools/schemas.ts
+++ b/src/wiki-tools/schemas.ts
@@ -1,55 +1,36 @@
 import { Type, type Static } from "@sinclair/typebox";
 
-export const FeishuWikiSchema = Type.Union([
-  Type.Object({
-    action: Type.Literal("spaces"),
-  }),
-  Type.Object({
-    action: Type.Literal("nodes"),
-    space_id: Type.String({ description: "Knowledge space ID" }),
-    parent_node_token: Type.Optional(
-      Type.String({ description: "Parent node token (optional, omit for root)" }),
-    ),
-  }),
-  Type.Object({
-    action: Type.Literal("get"),
-    token: Type.String({ description: "Wiki node token (from URL /wiki/XXX)" }),
-  }),
-  Type.Object({
-    action: Type.Literal("search"),
-    query: Type.String({ description: "Search query" }),
-    space_id: Type.Optional(Type.String({ description: "Limit search to this space (optional)" })),
-  }),
-  Type.Object({
-    action: Type.Literal("create"),
-    space_id: Type.String({ description: "Knowledge space ID" }),
-    title: Type.String({ description: "Node title" }),
-    obj_type: Type.Optional(
-      Type.Union([Type.Literal("docx"), Type.Literal("sheet"), Type.Literal("bitable")], {
-        description: "Object type (default: docx)",
-      }),
-    ),
-    parent_node_token: Type.Optional(
-      Type.String({ description: "Parent node token (optional, omit for root)" }),
-    ),
-  }),
-  Type.Object({
-    action: Type.Literal("move"),
-    space_id: Type.String({ description: "Source knowledge space ID" }),
-    node_token: Type.String({ description: "Node token to move" }),
-    target_space_id: Type.Optional(
-      Type.String({ description: "Target space ID (optional, same space if omitted)" }),
-    ),
-    target_parent_token: Type.Optional(
-      Type.String({ description: "Target parent node token (optional, root if omitted)" }),
-    ),
-  }),
-  Type.Object({
-    action: Type.Literal("rename"),
-    space_id: Type.String({ description: "Knowledge space ID" }),
-    node_token: Type.String({ description: "Node token to rename" }),
-    title: Type.String({ description: "New title" }),
-  }),
-]);
+function stringEnum<T extends readonly string[]>(
+  values: T,
+  options: { description?: string; default?: T[number] } = {},
+) {
+  return Type.Unsafe<T[number]>({ type: "string", enum: [...values], ...options });
+}
+
+const WIKI_ACTION_VALUES = ["spaces", "nodes", "get", "search", "create", "move", "rename"] as const;
+const WIKI_OBJ_TYPE_VALUES = ["docx", "sheet", "bitable"] as const;
+
+export const FeishuWikiSchema = Type.Object({
+  action: stringEnum(WIKI_ACTION_VALUES, { description: "Wiki action" }),
+  space_id: Type.Optional(Type.String({ description: "Knowledge space ID" })),
+  parent_node_token: Type.Optional(
+    Type.String({ description: "Parent node token (optional, omit for root)" }),
+  ),
+  token: Type.Optional(Type.String({ description: "Wiki node token (from URL /wiki/XXX)" })),
+  query: Type.Optional(Type.String({ description: "Search query" })),
+  title: Type.Optional(Type.String({ description: "Node title / new title" })),
+  obj_type: Type.Optional(
+    stringEnum(WIKI_OBJ_TYPE_VALUES, {
+      description: "Object type for create action (default: docx)",
+    }),
+  ),
+  node_token: Type.Optional(Type.String({ description: "Node token" })),
+  target_space_id: Type.Optional(
+    Type.String({ description: "Target space ID (optional, same space if omitted)" }),
+  ),
+  target_parent_token: Type.Optional(
+    Type.String({ description: "Target parent node token (optional, root if omitted)" }),
+  ),
+});
 
 export type FeishuWikiParams = Static<typeof FeishuWikiSchema>;


### PR DESCRIPTION
## Summary
- flatten feishu_doc, feishu_wiki, feishu_drive, feishu_perm, and feishu_chat schemas to top-level Type.Object
- replace literal union enums with stringEnum patterns to avoid anyOf generation
- add runtime required-field guards in action dispatchers after schema flattening
- expand schema compatibility tests to include chat/urgent and assert no anyOf/oneOf/allOf at any depth

## Why
Some providers (including ChatGPT tool validation flows) can reject schemas containing composition keywords like anyOf/oneOf/allOf.

## Validation
- npx tsc --noEmit
- npx vitest run src/__tests__/tool-schema-compat.test.ts
- npm run -s test:unit