### PR TITLE
fix: skip dedup check for bots own messages

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -911,9 +911,13 @@ export async function handleFeishuMessage(params: {
   const error = runtime?.error ?? console.error;
 
   // Dedup check: skip if this message was already processed
+  // But don't skip bot's own messages (they will be received via WebSocket after sending)
   const messageId = event.message.message_id;
+  const senderOpenId = event.sender?.sender_id?.open_id || "";
+  const isBotMessage = botOpenId && senderOpenId === botOpenId;
+
   const dedupAccountId = accountId || "default";
-  if (!tryRecordMessage(messageId, dedupAccountId)) {
+  if (!isBotMessage && !tryRecordMessage(messageId, dedupAccountId)) {
     log(`feishu: skipping duplicate message ${messageId}`);
     return;
   }


### PR DESCRIPTION
## Description

When the bot sends a reply message, it receives the message via WebSocket and incorrectly identifies it as a duplicate by tryRecordMessage, causing the reply to be skipped.

This fix adds a check to see if the message sender is the bot itself (by comparing senders open_id with botOpenId), and skips the dedup check for messages from the bot.

## Related Issue

Fixes #387

## Changes

In src/bot.ts, added a check to skip dedup for bots own messages.