### PR TITLE
fix: clarify local file vs Feishu Drive routing for issue #394

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -60,6 +60,8 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
     messageToolHints: () => [
       "- Feishu targeting: omit `target` to reply to the current conversation (auto-inferred). Explicit targets: `user:open_id` or `chat:chat_id`.",
       "- Feishu supports interactive cards for rich messages.",
+      "- To send a file from the OpenClaw agent's local filesystem workspace (or another allowed local path) as a Feishu attachment, reply with a standalone `MEDIA:<absolute-path-or-url>` line.",
+      "- `feishu_drive` is for Feishu cloud Drive content, not for the OpenClaw agent's local filesystem workspace.",
     ],
   },
   groups: {

--- a/src/drive-tools/register.ts
+++ b/src/drive-tools/register.ts
@@ -59,7 +59,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     name: "feishu_drive",
     label: "Feishu Drive",
     description:
-      "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete, import_document. Use 'import_document' to create documents from Markdown with better structure preservation than block-by-block writing.",
+      "Feishu cloud Drive operations. This tool works with Feishu Drive folders/files/documents, not the OpenClaw agent's local filesystem workspace. Actions: list, info, create_folder, move, delete, import_document. Use 'import_document' to create documents from Markdown with better structure preservation than block-by-block writing.",
     parameters: FeishuDriveSchema,
     run: async ({ client, account }, params) => {
       const mediaMaxBytes = (account.config?.mediaMaxMb ?? 30) * 1024 * 1024;


### PR DESCRIPTION
## Summary
- clarify that local files from the OpenClaw agent filesystem workspace should be sent via MEDIA:<path>
- clarify that feishu_drive is for Feishu Drive cloud content, not the agent local filesystem workspace
- reduce ambiguity behind issue #394 where the agent appeared to choose the wrong tool path