### PR TITLE
feat(doc): add create_diagram action for Mermaid/PlantUML blocks

### DIFF
--- a/skills/feishu-doc/SKILL.md
+++ b/skills/feishu-doc/SKILL.md
@@ -135,6 +135,18 @@ Returns all comments for the document. Use `page_token` for pagination. Comments
 Current tool provides documented comment write action `create_comment` (global comment creation).
 For replies, use `list_comment_replies` for retrieval; the reply creation endpoint is not exposed in current SDK surface.
 
+### Create Diagram (Mermaid)
+
+```json
+{
+  "action": "create_diagram",
+  "doc_token": "ABC123def",
+  "content": "sequenceDiagram\n    A->>B: Hello\n    B-->>A: Hi"
+}
+```
+
+Inserts a rendered Mermaid diagram block into the document. The diagram is rendered natively by Feishu's built-in Mermaid add-on component. Pass the Mermaid source code as `content` (without the `` ```mermaid `` fence).
+
 ## Reading Workflow
 
 1. Start with `action: "read"` - get plain text + statistics

--- a/src/doc-tools/actions.ts
+++ b/src/doc-tools/actions.ts
@@ -2,6 +2,13 @@ import { appendDoc, createAndWriteDoc, createDoc, writeDoc } from "../doc-write-
 import { detectDocFormat, runDocApiCall, type DocClient } from "./common.js";
 import type { FeishuDocParams } from "./schemas.js";
 
+/**
+ * Feishu component_type_id for the Mermaid diagram add-on block.
+ * This is a stable constant used by the Feishu editor (block_type 40).
+ * Verified by reading existing Mermaid blocks via list_blocks.
+ */
+const MERMAID_COMPONENT_TYPE_ID = "blk_631fefbbae02400430b8f9f4";
+
 const BLOCK_TYPE_NAMES: Record<number, string> = {
   1: "Page",
   2: "Text",
@@ -304,6 +311,70 @@ export async function listAppScopes(client: DocClient) {
   };
 }
 
+/**
+ * Create a Mermaid diagram block in a Feishu document.
+ *
+ * Feishu renders diagrams as add-on component blocks (block_type 40).
+ * The Lark SDK's `documentBlockChildren.create` performs client-side
+ * validation that rejects block_type 40, so we use the raw HTTP API
+ * endpoint directly to bypass this limitation.
+ */
+async function createDiagram(
+  client: DocClient,
+  docToken: string,
+  content: string,
+) {
+  const record = JSON.stringify({
+    data: content,
+    theme: "default",
+    view: "chart",
+  });
+
+  // Use client.httpInstance (axios) instead of bare fetch to respect
+  // proxy settings configured via https_proxy / HTTP_PROXY env vars.
+  // This matches the pattern used by readLegacyDoc.
+  const domain = (client as any).domain ?? "https://open.feishu.cn";
+  const token = await client.tokenManager.getTenantAccessToken();
+  const url = `${domain}/open-apis/docx/v1/documents/${docToken}/blocks/${docToken}/children`;
+
+  const response = await runDocApiCall("docx.createDiagram", async () => {
+    const resp = await client.httpInstance.post<{
+      code?: number;
+      msg?: string;
+      log_id?: string;
+      data?: { children?: unknown[] };
+    }>(url, {
+      children: [
+        {
+          block_type: 40,
+          add_ons: {
+            component_type_id: MERMAID_COMPONENT_TYPE_ID,
+            record,
+          },
+        },
+      ],
+    }, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+    });
+
+    // axios wraps the body in resp.data
+    const body = (resp as any).data ?? resp;
+    return body as { code?: number; msg?: string; log_id?: string; data?: { children?: unknown[] } };
+  });
+
+  const children = (response as any).data?.children ?? [];
+  const diagramBlock = children.find((b: any) => b.block_type === 40);
+
+  return {
+    success: true,
+    block_id: diagramBlock?.block_id,
+    children_count: children.length,
+  };
+}
+
 export async function runDocAction(
   client: DocClient,
   params: FeishuDocParams,
@@ -383,6 +454,12 @@ export async function runDocAction(
         requireString(params.comment_id, "comment_id"),
         params.page_token,
         params.page_size,
+      );
+    case "create_diagram":
+      return createDiagram(
+        client,
+        requireString(params.doc_token, "doc_token"),
+        requireString(params.content, "content"),
       );
     default:
       return { error: `Unknown action: ${(params as any).action}` };

--- a/src/doc-tools/register.ts
+++ b/src/doc-tools/register.ts
@@ -60,7 +60,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
       name: "feishu_doc",
       label: "Feishu Doc",
       description:
-        'Feishu document operations. Actions: read, write, append, create, create_and_write, list_blocks, get_block, update_block, delete_block, list_comments, create_comment, get_comment, list_comment_replies. Use "create_and_write" for atomic create + content write.',
+        'Feishu document operations. Actions: read, write, append, create, create_and_write, list_blocks, get_block, update_block, delete_block, list_comments, create_comment, get_comment, list_comment_replies, create_diagram. Use "create_and_write" for atomic create + content write. Use "create_diagram" with Mermaid source code to insert rendered diagrams.',
       parameters: FeishuDocSchema,
       requiredTool: "doc",
       run: async ({ client, account }, params) => {

--- a/src/doc-tools/schemas.ts
+++ b/src/doc-tools/schemas.ts
@@ -21,6 +21,7 @@ const DOC_ACTION_VALUES = [
   "create_comment",
   "get_comment",
   "list_comment_replies",
+  "create_diagram",
 ] as const;
 
 export const FeishuDocSchema = Type.Object({


### PR DESCRIPTION
## Summary

Add `create_diagram` action to `feishu_doc` tool for inserting rendered Mermaid diagrams into Feishu documents.

## Problem

Feishu documents support native Mermaid diagram rendering via component blocks (`block_type: 40`), but there was no way to create these programmatically through the doc tool. The Lark SDK's `documentBlockChildren.create` performs client-side validation that rejects `block_type 40`.

## Solution

Bypass the SDK validation by using the raw HTTP API endpoint directly — the same pattern already used by `readLegacyDoc`. The Feishu server API accepts `block_type 40` with the correct `add_ons` structure.

The Mermaid `component_type_id` (`blk_631fefbbae02400430b8f9f4`) was verified by reading existing Mermaid blocks from a real document via `list_blocks`.

### Usage

```json
{
  "action": "create_diagram",
  "doc_token": "ABC123def",
  "content": "sequenceDiagram\nA->>B: Hello\nB-->>A: Hi"
}
```

## Changes

- `src/doc-tools/schemas.ts`: Add `create_diagram` to action enum
- `src/doc-tools/actions.ts`: Implement `createDiagram()` using raw HTTP (same pattern as `readLegacyDoc`)
- `src/doc-tools/register.ts`: Update tool description
- `skills/feishu-doc/SKILL.md`: Document new action

## Testing

- `tsc --noEmit`: ✅
- Unit tests: all pass (pre-existing timeout in `bot.pairing-compat.test.ts`, unrelated)
- Manual: verified on Feishu production — diagram block created and renders correctly in editor