### PR TITLE
fix: resolve streaming card duplicate content and ghost second card

### DIFF
--- a/src/__tests__/merge-streaming-text.test.ts
+++ b/src/__tests__/merge-streaming-text.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { mergeStreamingText } from "../streaming-card.js";
+
+describe("mergeStreamingText", () => {
+  it("returns next when previous is empty", () => {
+    expect(mergeStreamingText("", "hello")).toBe("hello");
+    expect(mergeStreamingText(undefined, "hello")).toBe("hello");
+  });
+
+  it("returns previous when next is empty", () => {
+    expect(mergeStreamingText("hello", "")).toBe("hello");
+    expect(mergeStreamingText("hello", undefined)).toBe("hello");
+  });
+
+  it("returns next for cumulative partials (next includes previous)", () => {
+    expect(mergeStreamingText("hello", "hello world")).toBe("hello world");
+    expect(mergeStreamingText("AB", "ABCD")).toBe("ABCD");
+  });
+
+  it("returns previous when previous already includes next", () => {
+    expect(mergeStreamingText("hello world", "hello")).toBe("hello world");
+    expect(mergeStreamingText("ABCD", "BC")).toBe("ABCD");
+  });
+
+  it("detects partial overlap between segments", () => {
+    // After a tool call, partials restart within a new segment.
+    // previous ends with the start of next.
+    expect(mergeStreamingText("Prior text. 找到了", "找到了！")).toBe("Prior text. 找到了！");
+    expect(mergeStreamingText("Prior text. 找到了！", "找到了！是")).toBe("Prior text. 找到了！是");
+    expect(mergeStreamingText("ABCD", "CDEF")).toBe("ABCDEF");
+  });
+
+  it("appends truly incremental chunks with no overlap", () => {
+    expect(mergeStreamingText("hello", " world")).toBe("hello world");
+    expect(mergeStreamingText("ABC", "XYZ")).toBe("ABCXYZ");
+  });
+
+  it("handles identical texts", () => {
+    expect(mergeStreamingText("same", "same")).toBe("same");
+  });
+
+  it("simulates full tool-call streaming scenario", () => {
+    // Phase 1: initial response (cumulative partials)
+    let text = mergeStreamingText("", "Let me search");
+    expect(text).toBe("Let me search");
+    text = mergeStreamingText(text, "Let me search for that:");
+    expect(text).toBe("Let me search for that:");
+
+    // Phase 2: after tool call, partials restart within new segment
+    text = mergeStreamingText(text, "Found");
+    expect(text).toBe("Let me search for that:Found");
+    text = mergeStreamingText(text, "Found it!");
+    expect(text).toBe("Let me search for that:Found it!");
+    text = mergeStreamingText(text, "Found it! The answer is 42.");
+    expect(text).toBe("Let me search for that:Found it! The answer is 42.");
+  });
+});

--- a/src/__tests__/reply-dispatcher.test.ts
+++ b/src/__tests__/reply-dispatcher.test.ts
@@ -52,16 +52,20 @@ vi.mock("../mention.js", () => ({
 vi.mock("../text/markdown-links.js", () => ({
   normalizeFeishuMarkdownLinks: normalizeFeishuMarkdownLinksMock,
 }));
-vi.mock("../streaming-card.js", () => ({
-  FeishuStreamingSession: class {
-    active = false;
-    start = vi.fn(async () => { this.active = true; });
-    update = vi.fn(async () => {});
-    close = vi.fn(async () => { this.active = false; });
-    isActive = vi.fn(() => this.active);
-    constructor() { streamingInstances.push(this as never); }
-  },
-}));
+vi.mock("../streaming-card.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../streaming-card.js")>();
+  return {
+    mergeStreamingText: actual.mergeStreamingText,
+    FeishuStreamingSession: class {
+      active = false;
+      start = vi.fn(async () => { this.active = true; });
+      update = vi.fn(async () => {});
+      close = vi.fn(async () => { this.active = false; });
+      isActive = vi.fn(() => this.active);
+      constructor() { streamingInstances.push(this as never); }
+    },
+  };
+});
 
 import { createFeishuReplyDispatcher } from "../reply-dispatcher.js";
 
@@ -184,6 +188,94 @@ describe("createFeishuReplyDispatcher — block payload handling", () => {
     await opts.onIdle();
 
     expect(streamingInstances[0]!.close).toHaveBeenCalledWith("```ts\nfinal text\n```");
+  });
+});
+
+describe("createFeishuReplyDispatcher — thinking block deduplication (#399)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    streamingInstances.length = 0;
+    resolveFeishuAccountMock.mockReturnValue({
+      ...defaultAccountConfig,
+      config: { renderMode: "card", streaming: true },
+    });
+    resolveReceiveIdTypeMock.mockReturnValue("chat_id");
+    createFeishuClientMock.mockReturnValue({});
+    normalizeFeishuMarkdownLinksMock.mockImplementation((t: string) => t);
+    createReplyDispatcherWithTypingMock.mockImplementation(() => ({
+      dispatcher: {},
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+    }));
+    getFeishuRuntimeMock.mockReturnValue(defaultRuntime);
+  });
+
+  it("does not duplicate thinking text when partials arrive before block payload", async () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+    const opts = getLastOpts();
+    const { onPartialReply } = result.replyOptions;
+
+    // Start streaming session
+    opts.onReplyStart();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const instance = streamingInstances[0]!;
+
+    // Simulate thinking tokens arriving via onPartialReply (cumulative)
+    onPartialReply!({ text: "thinking step 1" });
+    onPartialReply!({ text: "thinking step 1\nthinking step 2" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Then response tokens start
+    onPartialReply!({ text: "thinking step 1\nthinking step 2\nresponse start" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Now the block payload arrives with the same thinking text
+    await opts.deliver(
+      { text: "thinking step 1\nthinking step 2" },
+      { kind: "block" },
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The last update should NOT contain duplicated thinking
+    const lastUpdateCall = instance.update.mock.calls[instance.update.mock.calls.length - 1];
+    const lastText = lastUpdateCall?.[0] as string | undefined;
+    if (lastText) {
+      const thinkingOccurrences = lastText.split("thinking step 1").length - 1;
+      expect(thinkingOccurrences).toBe(1);
+    }
+  });
+
+  it("still accepts block content when no partials have arrived", async () => {
+    makeDispatcher();
+    const opts = getLastOpts();
+
+    // Block arrives without any prior partials (regression #30663)
+    await opts.deliver({ text: "```ts\nreasoning block\n```" }, { kind: "block" });
+    await opts.onIdle();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0]!.close).toHaveBeenCalledWith("```ts\nreasoning block\n```");
+  });
+
+  it("does not send a second card after streaming closes (#399)", async () => {
+    makeDispatcher();
+    const opts = getLastOpts();
+
+    // First deliver closes the streaming card
+    await opts.deliver({ text: "```ts\nfinal\n```" }, { kind: "final" });
+
+    // Second deliver arrives after streaming is already closed
+    await opts.deliver({ text: "```ts\nfinal\n```" }, { kind: "final" });
+
+    // Should NOT fall through to sendMarkdownCardFeishu
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -12,7 +12,7 @@ import { buildMentionedCardContent, type MentionTarget } from "./mention.js";
 import { normalizeFeishuMarkdownLinks } from "./text/markdown-links.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
-import { FeishuStreamingSession } from "./streaming-card.js";
+import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
@@ -119,39 +119,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
   let lastPartial = "";
+  let streamingCompleted = false;
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
 
-  const mergeStreamingText = (nextText: string) => {
-    if (!streamText) {
-      streamText = nextText;
-      return;
-    }
-    if (nextText.startsWith(streamText)) {
-      // Handle cumulative partial payloads where nextText already includes prior text.
-      streamText = nextText;
-      return;
-    }
-    if (streamText.endsWith(nextText)) {
-      return;
-    }
-    streamText += nextText;
+  const mergeIntoStreamText = (nextText: string) => {
+    streamText = mergeStreamingText(streamText, nextText);
   };
 
-  const queueStreamingUpdate = (
-    nextText: string,
-    options?: { dedupeWithLastPartial?: boolean },
-  ) => {
-    if (!nextText) {
-      return;
-    }
-    if (options?.dedupeWithLastPartial && nextText === lastPartial) {
-      return;
-    }
-    if (options?.dedupeWithLastPartial) {
-      lastPartial = nextText;
-    }
-    mergeStreamingText(nextText);
+  const enqueueStreamingFlush = () => {
     partialUpdateQueue = partialUpdateQueue.then(async () => {
       if (streamingStartPromise) {
         await streamingStartPromise;
@@ -163,7 +139,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const startStreaming = () => {
-    if (!streamingEnabled || streamingStartPromise || streaming) {
+    if (!streamingEnabled || streamingStartPromise || streaming || streamingCompleted) {
       return;
     }
     streamingStartPromise = (async () => {
@@ -198,6 +174,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         text = buildMentionedCardContent(mentionTargets, text);
       }
       await streaming.close(normalizeFeishuMarkdownLinks(text));
+      streamingCompleted = true;
     }
     streaming = null;
     streamingStartPromise = null;
@@ -247,12 +224,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           if (info?.kind === "block") {
             // Some runtimes emit block payloads without onPartial/final callbacks.
             // Mirror block text into streamText so onIdle close still sends content.
-            queueStreamingUpdate(text);
+            mergeIntoStreamText(text);
+            enqueueStreamingFlush();
           }
           if (info?.kind === "final") {
             streamText = text;
             await closeStreaming();
           }
+          return;
+        }
+
+        // Streaming card already delivered the content — skip regular send to
+        // avoid a duplicate card when the runtime delivers a second payload
+        // after the streaming session has closed (#399).
+        if (streamingCompleted) {
           return;
         }
 
@@ -312,10 +297,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             const partialText = normalizeFeishuMarkdownLinks(payload.text ?? "");
-            if (!partialText) {
+            if (!partialText || partialText === lastPartial) {
               return;
             }
-            queueStreamingUpdate(partialText, { dedupeWithLastPartial: true });
+            lastPartial = partialText;
+            // Partials are cumulative — replace streamText directly instead of
+            // merging, which avoids duplication when segment boundaries shift
+            // (e.g. after a tool call mid-stream).
+            streamText = partialText;
+            enqueueStreamingFlush();
           }
         : undefined,
     },

--- a/src/streaming-card.ts
+++ b/src/streaming-card.ts
@@ -44,6 +44,21 @@ async function getToken(creds: Credentials): Promise<string> {
   return data.tenant_access_token;
 }
 
+/**
+ * Find the length of the longest suffix of `a` that equals a prefix of `b`.
+ * Used to detect partial overlaps between consecutive streaming segments.
+ * Capped at 500 chars to keep cost bounded.
+ */
+function findOverlapLength(a: string, b: string): number {
+  const max = Math.min(a.length, b.length, 500);
+  for (let len = max; len > 0; len--) {
+    if (a.endsWith(b.slice(0, len))) {
+      return len;
+    }
+  }
+  return 0;
+}
+
 export function mergeStreamingText(
   previousText: string | undefined,
   nextText: string | undefined,
@@ -59,7 +74,14 @@ export function mergeStreamingText(
   if (previous.includes(next)) {
     return previous;
   }
-  // Fallback for fragmented partial chunks: append to avoid losing tokens.
+  // Detect partial overlap: the end of previous matches the start of next.
+  // This happens when partials are cumulative within a segment but don't
+  // include prior segments (e.g. after a tool call mid-stream).
+  const overlap = findOverlapLength(previous, next);
+  if (overlap > 0) {
+    return previous + next.slice(overlap);
+  }
+  // No overlap — truly incremental chunk, just append.
   return `${previous}${next}`;
 }
 
@@ -147,30 +169,30 @@ export class FeishuStreamingSession {
   }
 
   async update(text: string): Promise<void> {
-    if (!this.state || this.closed) {
+    if (!this.state || this.closed || !text) {
       return;
     }
-    const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
-    if (!mergedInput || mergedInput === this.state.currentText) {
+    // Caller sends cumulative full text — no merge needed, just throttle.
+    if (text === this.state.currentText) {
       return;
     }
     const now = Date.now();
     if (now - this.lastUpdateTime < this.updateThrottleMs) {
-      this.pendingText = mergedInput;
+      this.pendingText = text;
       return;
     }
     this.pendingText = null;
     this.lastUpdateTime = now;
 
+    const toSend = text;
     this.queue = this.queue.then(async () => {
       if (!this.state || this.closed) {
         return;
       }
-      const mergedText = mergeStreamingText(this.state.currentText, mergedInput);
-      if (!mergedText || mergedText === this.state.currentText) {
+      if (toSend === this.state.currentText) {
         return;
       }
-      this.state.currentText = mergedText;
+      this.state.currentText = toSend;
       this.state.sequence += 1;
       const apiBase = resolveApiBase(this.creds.domain);
       await fetch(`${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`, {
@@ -180,7 +202,7 @@ export class FeishuStreamingSession {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          content: mergedText,
+          content: toSend,
           sequence: this.state.sequence,
           uuid: `s_${this.state.cardId}_${this.state.sequence}`,
         }),
@@ -196,8 +218,9 @@ export class FeishuStreamingSession {
     this.closed = true;
     await this.queue;
 
-    const pendingMerged = mergeStreamingText(this.state.currentText, this.pendingText ?? undefined);
-    const text = finalText ? mergeStreamingText(pendingMerged, finalText) : pendingMerged;
+    // finalText is authoritative when provided (from deliver kind=final).
+    // Fall back to pending or current text when closing via onIdle.
+    const text = finalText || this.pendingText || this.state.currentText;
     const apiBase = resolveApiBase(this.creds.domain);
 
     if (text && text !== this.state.currentText) {


### PR DESCRIPTION
## Summary

- **Remove all merge logic from `FeishuStreamingSession`** — `update()` and `close()` now just throttle and forward full text. The session no longer accumulates or deduplicates internally, eliminating the root cause of content duplication within the streaming card.
- **Single source of truth for stream text** — `onPartialReply` directly replaces `streamText` (partials are cumulative from the runtime), while block payloads use `mergeStreamingText` only as a fallback for runtimes without partial support.
- **Prevent ghost second card** — Added `streamingCompleted` guard so that after a streaming session closes, no new session is created and no regular send fallthrough occurs. This fixes the brief "Thinking..." card that appeared near the end of generation.
- **Extract `mergeStreamingText` with overlap detection** — Moved to `streaming-card.ts` as a shared export with dedicated tests covering cumulative partials, substring containment, partial overlap, and incremental chunks.

Fixes #378 #399
Likely also fixes #395 (no notification after card generation — caused by the ghost second card creation)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 124 tests pass (`pnpm test`)
- [x] New `merge-streaming-text.test.ts` covers merge edge cases
- [x] New tests in `reply-dispatcher.test.ts` cover thinking block deduplication and second-card prevention
- [x] Manual verification with streaming-enabled Feishu account: confirm single card with no duplicated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)