### PR TITLE
feat: discard stale messages replayed after gateway restart

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -94,6 +94,7 @@ const senderNameCache = new Map<string, { name: string; expireAt: number }>();
 // Key: appId or "default", Value: timestamp of last notification
 const permissionErrorNotifiedAt = new Map<string, number>();
 const PERMISSION_ERROR_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_MAX_MESSAGE_AGE_MS = 300_000; // 5 minutes
 
 type SenderNameResult = {
   name?: string;
@@ -918,12 +919,19 @@ export async function handleFeishuMessage(params: {
     return;
   }
 
-  let ctx = parseFeishuMessageEvent(event, botOpenId);
-
   // Parse message create_time (Feishu uses millisecond epoch string).
   const messageCreateTimeMs = event.message.create_time
     ? parseInt(event.message.create_time, 10)
     : undefined;
+
+  // Discard stale messages (e.g. replayed after gateway restart).
+  const maxAgeMs = feishuCfg.maxMessageAgeMs ?? DEFAULT_MAX_MESSAGE_AGE_MS;
+  if (messageCreateTimeMs && Date.now() - messageCreateTimeMs > maxAgeMs) {
+    log(`feishu[${account.accountId}]: discarding stale message ${messageId} (age: ${Math.round((Date.now() - messageCreateTimeMs) / 1000)}s, max: ${maxAgeMs / 1000}s)`);
+    return;
+  }
+
+  let ctx = parseFeishuMessageEvent(event, botOpenId);
 
   const messageType = event.message.message_type;
   const isForwardedInbound = isForwardedMessageType(messageType);

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -157,6 +157,7 @@ export const FeishuAccountConfigSchema = z
     mediaMaxMb: z.number().positive().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    maxMessageAgeMs: z.number().positive().optional(),
     renderMode: RenderModeSchema,
     streaming: StreamingModeSchema,
     tools: FeishuToolsConfigSchema,
@@ -196,6 +197,7 @@ export const FeishuConfigSchema = z
     mediaMaxMb: z.number().positive().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    maxMessageAgeMs: z.number().positive().optional(),
     renderMode: RenderModeSchema, // raw = plain text (default), card = interactive card with markdown
     streaming: StreamingModeSchema,
     tools: FeishuToolsConfigSchema,


### PR DESCRIPTION
## Summary
- When the gateway restarts or WebSocket reconnects, Feishu re-delivers offline messages with new `message_id`s that bypass existing dedup. Users receive late replies to stale messages.
- Add a `maxMessageAgeMs` staleness check (default 5 min) in `bot.ts` right after dedup, comparing `message.create_time` against current time.
- Configurable via `maxMessageAgeMs` at top-level or per-account config.

Related #259

## Test plan
- [x] Verify normal messages (age < 5min) are processed as before
- [x] Verify stale messages (age > 5min) are discarded with log entry
- [x] Verify custom `maxMessageAgeMs` config overrides default
- [x] Verify per-account override works
- [x] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)