### PR TITLE
chore: bump openclaw SDK to 2026.3.13 and migrate feishu subpath imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
   "devDependencies": {
     "@types/node": "^25.0.10",
     "@vitest/coverage-v8": "^2.1.8",
-    "openclaw": "2026.3.1",
+    "openclaw": "2026.3.13",
     "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.3.1"
+    "openclaw": ">=2026.3.13"
   }
 }

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -1,11 +1,13 @@
 import {
-  createReplyPrefixContext,
-  createTypingCallbacks,
-  logTypingFailure,
   type ClawdbotConfig,
   type ReplyPayload,
   type RuntimeEnv,
 } from "openclaw/plugin-sdk";
+import {
+  createReplyPrefixContext,
+  createTypingCallbacks,
+  logTypingFailure,
+} from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { buildMentionedCardContent, type MentionTarget } from "./mention.js";


### PR DESCRIPTION
## Summary
- Bump openclaw SDK 2026.3.1 → 2026.3.13
- Move `createReplyPrefixContext` / `createTypingCallbacks` / `logTypingFailure` imports to `openclaw/plugin-sdk/feishu` subpath

## Context
Upstream openclaw is restructuring `plugin-sdk` exports into per-channel subpaths. The main `openclaw/plugin-sdk` entry is now intentionally minimal.

Companion upstream PR: openclaw/openclaw#49881 (adds 2 missing exports to `plugin-sdk/feishu`).

Depends on #425 (static monitor import fix).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `pnpm run test:unit` — 132/132 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)