### PR TITLE
fix: convert dynamic monitor import to static

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -8,6 +8,7 @@ import {
   listFeishuAccountIds,
   resolveDefaultFeishuAccountId,
 } from "./accounts.js";
+import { monitorFeishuProvider } from "./monitor.js";
 import { feishuOutbound } from "./outbound.js";
 import { probeFeishu } from "./probe.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
@@ -327,7 +328,6 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
   },
   gateway: {
     startAccount: async (ctx) => {
-      const { monitorFeishuProvider } = await import("./monitor.js");
       const account = resolveFeishuAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
       const port = account.config?.webhookPort ?? null;
       ctx.setStatus({ accountId: ctx.accountId, port });


### PR DESCRIPTION
## Summary
- Convert `await import("./monitor.js")` in `channel.ts` to a static import

## Context
OpenClaw's jiti plugin loader now uses `tryNative: true`, which delegates dynamic `import()` to Node's native ESM resolver. Since this plugin ships `.ts` source (no build step), Node cannot resolve `.js` → `.ts` for dynamic imports. Static imports are handled by jiti correctly.

No circular dependency risk — nothing in the `monitor.ts` import tree imports `channel.ts`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] 132/132 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)