### PR TITLE
feat: replace age-based dedup with watermark tracking

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -11,7 +11,7 @@ import type { FeishuConfig, FeishuMessageContext, FeishuMediaInfo, ResolvedFeish
 import { getFeishuRuntime } from "./runtime.js";
 import { createFeishuClient } from "./client.js";
 import { resolveFeishuAccount } from "./accounts.js";
-import { tryRecordMessage } from "./dedup.js";
+import { tryRecordMessage, tryCheckWatermark } from "./dedup.js";
 import {
   resolveFeishuGroupConfig,
   resolveFeishuReplyPolicy,
@@ -94,7 +94,6 @@ const senderNameCache = new Map<string, { name: string; expireAt: number }>();
 // Key: appId or "default", Value: timestamp of last notification
 const permissionErrorNotifiedAt = new Map<string, number>();
 const PERMISSION_ERROR_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
-const DEFAULT_MAX_MESSAGE_AGE_MS = 300_000; // 5 minutes
 
 type SenderNameResult = {
   name?: string;
@@ -919,16 +918,21 @@ export async function handleFeishuMessage(params: {
     return;
   }
 
-  // Parse message create_time (Feishu uses millisecond epoch string).
+  // Discard stale messages (e.g. replayed after gateway restart).
   const messageCreateTimeMs = event.message.create_time
     ? parseInt(event.message.create_time, 10)
     : undefined;
 
-  // Discard stale messages (e.g. replayed after gateway restart).
-  const maxAgeMs = feishuCfg.maxMessageAgeMs ?? DEFAULT_MAX_MESSAGE_AGE_MS;
-  if (messageCreateTimeMs && Date.now() - messageCreateTimeMs > maxAgeMs) {
-    log(`feishu[${account.accountId}]: discarding stale message ${messageId} (age: ${Math.round((Date.now() - messageCreateTimeMs) / 1000)}s, max: ${maxAgeMs / 1000}s)`);
-    return;
+  if (messageCreateTimeMs) {
+    if (!tryCheckWatermark(account.accountId, event.message.chat_id, messageCreateTimeMs)) {
+      log(`feishu[${account.accountId}]: discarding stale message ${messageId} (watermark check failed)`);
+      return;
+    }
+  } else {
+    if (!tryRecordMessage(messageId, account.accountId)) {
+      log(`feishu[${account.accountId}]: duplicate message ${messageId}`);
+      return;
+    }
   }
 
   let ctx = parseFeishuMessageEvent(event, botOpenId);

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -158,7 +158,7 @@ export const FeishuAccountConfigSchema = z
     mediaMaxMb: z.number().positive().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
-    maxMessageAgeMs: z.number().positive().optional(),
+    maxMessageAgeMs: z.number().positive().optional(), // Deprecated: no longer used, kept for backward compatibility
     renderMode: RenderModeSchema,
     streaming: StreamingModeSchema,
     tools: FeishuToolsConfigSchema,
@@ -198,7 +198,7 @@ export const FeishuConfigSchema = z
     mediaMaxMb: z.number().positive().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
-    maxMessageAgeMs: z.number().positive().optional(),
+    maxMessageAgeMs: z.number().positive().optional(), // Deprecated: no longer used, kept for backward compatibility
     renderMode: RenderModeSchema, // raw = plain text (default), card = interactive card with markdown
     streaming: StreamingModeSchema,
     tools: FeishuToolsConfigSchema,

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -29,3 +29,17 @@ export function tryRecordMessage(messageId: string, scope = "default"): boolean 
   processedMessageIds.set(dedupKey, now);
   return true;
 }
+
+const chatWatermarks = new Map<string, number>();
+
+export function tryCheckWatermark(accountId: string, chatId: string, createTime: number): boolean {
+  const key = `${accountId}:${chatId}`;
+  const lastTime = chatWatermarks.get(key) ?? 0;
+
+  if (createTime <= lastTime) {
+    return false;
+  }
+
+  chatWatermarks.set(key, createTime);
+  return true;
+}


### PR DESCRIPTION
Replace maxMessageAgeMs with per-chat watermark tracking to handle Feishu WebSocket reconnect scenarios more precisely.

When Feishu reconnects, it replays recent messages. The old approach discarded messages older than maxMessageAgeMs, but this was too coarse.

New approach tracks the last processed create_time per (accountId, chatId). Messages with create_time <= watermark are discarded as stale. This ensures only truly new messages are processed after reconnect.


## What This PR Changes
<!--
Briefly explain what changed.
- For a fix: what problem is solved.
- For a feature: what is added.
-->

- Add tryCheckWatermark() in dedup.ts for watermark-based dedup
- Update bot.ts to use watermark check when create_time is available
- Fallback to tryRecordMessage() when create_time is missing
- Mark maxMessageAgeMs as deprecated in config schema (kept for compatibility)
- this will solve https://github.com/m1heng/clawdbot-feishu/issues/390

## Why (Optional)
<!--
A short reason is enough. If the linked issue already explains it, you can keep this brief.
-->

## How To Test
<!--
List simple steps to reproduce and verify, plus expected result.
-->

Install and restart the openclaw gateway

## Impact (Optional)
<!--
Any config, behavior, or docs impact. Write `None` if not applicable.
-->

## Related (Optional)
<!--
Link issues/discussions, e.g.:
- Closes #123
- Related #456
-->

