### PR TITLE
feat: resolve media from quoted/replied messages for vision analysis

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1388,7 +1388,7 @@ export async function handleFeishuMessage(params: {
 
     // Resolve media from message
     const mediaMaxBytes = (feishuCfg?.mediaMaxMb ?? 30) * 1024 * 1024; // 30MB default
-    const mediaList = await resolveFeishuMediaList({
+    let mediaList = await resolveFeishuMediaList({
       cfg,
       messageId: ctx.messageId,
       messageType: event.message.message_type,
@@ -1397,8 +1397,6 @@ export async function handleFeishuMessage(params: {
       log,
       accountId: account.accountId,
     });
-    const mediaPayload = buildFeishuMediaPayload(mediaList);
-
     // Fetch quoted/replied message content if parentId exists
     let quotedContent: string | undefined;
     if (ctx.parentId) {
@@ -1407,11 +1405,34 @@ export async function handleFeishuMessage(params: {
         if (quotedMsg) {
           quotedContent = quotedMsg.content;
           log(`feishu[${account.accountId}]: fetched quoted message ${ctx.parentId}`);
+
+          // Download media from quoted message if it contains images/files
+          if (quotedMsg.rawContent && mediaList.length === 0) {
+            try {
+              const quotedMedia = await resolveFeishuMediaList({
+                cfg,
+                messageId: quotedMsg.messageId,
+                messageType: quotedMsg.contentType,
+                content: quotedMsg.rawContent,
+                maxBytes: mediaMaxBytes,
+                log,
+                accountId: account.accountId,
+              });
+              if (quotedMedia.length > 0) {
+                mediaList.push(...quotedMedia);
+                log(`feishu[${account.accountId}]: resolved ${quotedMedia.length} media from quoted message`);
+              }
+            } catch (mediaErr) {
+              log(`feishu[${account.accountId}]: failed to resolve quoted media: ${String(mediaErr)}`);
+            }
+          }
         }
       } catch (err) {
         log(`feishu[${account.accountId}]: failed to fetch quoted message: ${String(err)}`);
       }
     }
+
+    const mediaPayload = buildFeishuMediaPayload(mediaList);
 
     const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
 

--- a/src/send.ts
+++ b/src/send.ts
@@ -16,6 +16,7 @@ export type FeishuMessageInfo = {
   content: string;
   contentType: string;
   createTime?: number;
+  rawContent?: string;
 };
 
 const MERGE_FORWARD_NAME_CACHE_TTL_MS = 10 * 60 * 1000;
@@ -428,6 +429,7 @@ export async function getMessageFeishu(params: {
       content: combinedContent,
       contentType: firstItem?.msg_type ?? "text",
       createTime: firstItem?.create_time ? parseInt(firstItem.create_time, 10) : undefined,
+      rawContent: firstItem?.body?.content ?? "",
     };
   } catch {
     return null;


### PR DESCRIPTION
## Problem

When a user sends an image in a Feishu group and then replies to that image message with `@bot describe this image`, the bot only receives the text content of the quoted message — the actual image data is never downloaded. The model sees a placeholder instead of the image, making vision analysis impossible for quoted messages.

This is a common workflow on Feishu mobile, where images and text are always sent as separate messages.

## Solution

Two minimal changes:

### `src/send.ts`
- Added `rawContent` field to `FeishuMessageInfo` type, preserving the original `body.content` JSON from the Feishu API (which contains `image_key` and other media references).

### `src/bot.ts`
- After fetching a quoted message via `getMessageFeishu()`, if the current message has no media (`mediaList.length === 0`), call `resolveFeishuMediaList()` on the quoted message using its `rawContent`, `messageId`, and `contentType`.
- Changed `mediaList` from `const` to `let` to allow appending quoted media.
- Moved `buildFeishuMediaPayload()` call to after the quoted message handling block.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| DM: send image directly | ✅ works | ✅ works (unchanged) |
| Group: send image directly (`requireMention: false`) | ✅ works | ✅ works (unchanged) |
| Group: reply to image + @bot | ❌ text placeholder only | ✅ image downloaded and sent to model |

Only downloads quoted media when the current message itself contains no media, avoiding duplicate downloads.

## Testing

Tested with:
- Feishu mobile → group chat → send image → reply with @bot
- Confirmed `resolveFeishuMediaList` downloads the image from the quoted message
- Confirmed model receives and correctly analyzes the image
- Verified no regression on direct image messages and DMs