### PR TITLE
fix: preserve reply sender context and document Xquik

### DIFF
--- a/src/__tests__/bot.from-routing.test.ts
+++ b/src/__tests__/bot.from-routing.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-async function setupHarness() {
+async function setupHarness(params?: {
+  getMessageFeishuImpl?: (args: { messageId: string }) => Promise<any>;
+}) {
   vi.resetModules();
   vi.clearAllMocks();
 
   const sendMessageFeishu = vi.fn(async () => undefined);
-  const getMessageFeishu = vi.fn(async () => null);
+  const getMessageFeishu = vi.fn<(args: { messageId: string }) => Promise<any>>(async () => null);
+  if (params?.getMessageFeishuImpl) {
+    getMessageFeishu.mockImplementation(params.getMessageFeishuImpl);
+  }
   vi.doMock("../send.js", () => ({ sendMessageFeishu, getMessageFeishu }));
 
   const createFeishuReplyDispatcher = vi.fn(() => ({
@@ -190,5 +195,42 @@ describe("From field routing", () => {
 
     // Different speakers are distinguishable
     expect(from1).not.toBe(from2);
+  });
+
+  it("preserves replied message sender metadata for agent attribution", async () => {
+    const harness = await setupHarness({
+      getMessageFeishuImpl: async ({ messageId }) => ({
+        messageId,
+        chatId: "oc_shared",
+        senderId: "ou_alice",
+        senderOpenId: "ou_alice",
+        senderName: "Alice",
+        content: "original statement",
+        contentType: "text",
+      }),
+    });
+
+    await harness.handleFeishuMessage({
+      cfg: buildCfg(),
+      event: {
+        sender: { sender_id: { open_id: "ou_bob", user_id: "u_bob" } },
+        message: {
+          message_id: "om_reply",
+          parent_id: "om_original",
+          chat_id: "oc_shared",
+          chat_type: "group",
+          message_type: "text",
+          content: JSON.stringify({ text: "follow-up" }),
+        },
+      },
+      accountId: "default",
+      runtime,
+    });
+
+    expect(harness.finalizeInboundContext).toHaveBeenCalledTimes(1);
+    const ctx = harness.finalizeInboundContext.mock.calls[0]?.[0];
+    expect(ctx.ReplyToBody).toBe("original statement");
+    expect(ctx.ReplyToSender).toBe("Alice (ou_alice)");
+    expect(ctx.RawBody).toContain('[Replying to Alice (ou_alice): "original statement"]');
   });
 });

--- a/src/__tests__/send.get-message.test.ts
+++ b/src/__tests__/send.get-message.test.ts
@@ -50,6 +50,47 @@ describe("getMessageFeishu", () => {
     expect(message?.contentType).toBe("text");
     expect(message?.content).toBe("hello world");
     expect(message?.senderOpenId).toBe("ou_sender");
+    expect(message?.senderName).toBe("open_id:ou_sender");
+  });
+
+  it("returns sender identity for quoted-message attribution", async () => {
+    const get = vi.fn(async () => ({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_quoted_1",
+            chat_id: "oc_chat_1",
+            msg_type: "text",
+            body: { content: JSON.stringify({ text: "original statement" }) },
+            sender: { id: "ou_alice", id_type: "open_id", sender_type: "user" },
+            create_time: "1700000000000",
+          },
+        ],
+      },
+    }));
+    const userGet = vi.fn(async () => ({
+      data: { user: { name: "Alice" } },
+    }));
+
+    vi.mocked(createFeishuClient).mockReturnValue({
+      im: {
+        message: { get },
+      },
+      contact: {
+        user: { get: userGet },
+      },
+    } as any);
+
+    const message = await getMessageFeishu({ cfg, messageId: "om_quoted_1" });
+
+    expect(userGet).toHaveBeenCalledWith({
+      path: { user_id: "ou_alice" },
+      params: { user_id_type: "open_id" },
+    });
+    expect(message?.senderId).toBe("ou_alice");
+    expect(message?.senderOpenId).toBe("ou_alice");
+    expect(message?.senderName).toBe("Alice");
   });
 
   it("resolves configured app display name for app sender in merge_forward", async () => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -101,6 +101,19 @@ type SenderNameResult = {
   permissionError?: PermissionError;
 };
 
+function formatReplySender(params: {
+  senderId?: string;
+  senderName?: string;
+}): string | undefined {
+  const senderId = params.senderId?.trim();
+  const senderName = params.senderName?.trim();
+  if (!senderName) return senderId;
+  if (!senderId || senderName === senderId || senderName.endsWith(`:${senderId}`)) {
+    return senderName;
+  }
+  return `${senderName} (${senderId})`;
+}
+
 type FeishuPairingApiMode = "legacy" | "scoped";
 let detectedFeishuPairingApiMode: FeishuPairingApiMode | null = null;
 
@@ -1401,11 +1414,13 @@ export async function handleFeishuMessage(params: {
 
     // Fetch quoted/replied message content if parentId exists
     let quotedContent: string | undefined;
+    let quotedSender: string | undefined;
     if (ctx.parentId) {
       try {
         const quotedMsg = await getMessageFeishu({ cfg, messageId: ctx.parentId, accountId: account.accountId });
         if (quotedMsg) {
           quotedContent = quotedMsg.content;
+          quotedSender = formatReplySender(quotedMsg);
           log(`feishu[${account.accountId}]: fetched quoted message ${ctx.parentId}`);
         }
       } catch (err) {
@@ -1426,7 +1441,8 @@ export async function handleFeishuMessage(params: {
       if (quoteAlreadyInBody) {
         log(`feishu[${account.accountId}]: skip duplicate quote merge for message ${ctx.messageId}`);
       } else {
-        rawBody = `[Replying to: "${quotedContent}"]\n\n${ctx.content}`;
+        const replyLabel = quotedSender ? ` ${quotedSender}` : "";
+        rawBody = `[Replying to${replyLabel}: "${quotedContent}"]\n\n${ctx.content}`;
       }
     }
 
@@ -1566,6 +1582,7 @@ export async function handleFeishuMessage(params: {
       OriginatingTo: feishuTo,
       GroupSystemPrompt: isGroup ? groupConfig?.systemPrompt?.trim() || undefined : undefined,
       ReplyToBody: quotedContent,
+      ReplyToSender: quotedSender,
       ...mediaPayload,
     });
 

--- a/src/send.ts
+++ b/src/send.ts
@@ -13,6 +13,7 @@ export type FeishuMessageInfo = {
   chatId: string;
   senderId?: string;
   senderOpenId?: string;
+  senderName?: string;
   content: string;
   contentType: string;
   createTime?: number;
@@ -230,7 +231,7 @@ function extractSenderLabelFromMessageBody(rawContent: string): string | undefin
   }
 }
 
-function buildMergeForwardSenderLabel(params: {
+function buildMessageSenderLabel(params: {
   cfg: ClawdbotConfig;
   rawContent: string;
   client: any;
@@ -400,7 +401,7 @@ export async function getMessageFeishu(params: {
         // Add sender label only for merge_forward expanded child messages.
         let prefix = "";
         if (hasExpandedMergeForwardChildren) {
-          const senderLabel = await buildMergeForwardSenderLabel({
+          const senderLabel = await buildMessageSenderLabel({
             cfg,
             rawContent,
             client,
@@ -419,12 +420,22 @@ export async function getMessageFeishu(params: {
       ? parsedContents.join("\n\n---\n\n")
       : (parsedContents[0] ?? "");
     const firstItem = items[0];
+    const senderName = firstItem
+      ? await buildMessageSenderLabel({
+          cfg,
+          rawContent: firstItem.body?.content ?? "",
+          client,
+          accountId: account.accountId,
+          sender: firstItem.sender,
+        })
+      : undefined;
 
     return {
       messageId: firstItem?.message_id ?? messageId,
       chatId: firstItem?.chat_id ?? "",
       senderId: firstItem?.sender?.id,
       senderOpenId: firstItem?.sender?.id_type === "open_id" ? firstItem?.sender?.id : undefined,
+      senderName,
       content: combinedContent,
       contentType: firstItem?.msg_type ?? "text",
       createTime: firstItem?.create_time ? parseInt(firstItem.create_time, 10) : undefined,


### PR DESCRIPTION
## What This PR Changes

- Preserves the replied message sender ID and best-effort display name.
- Sets `ReplyToSender` and labels quoted content for reliable attribution.
- Adds English and Chinese Xquik workflows through the official TweetClaw plugin.
- Documents ClawHub installation, optional tools, runtime checks, approvals, and credential handling.

## Why (Optional)

Feishu group-topic replies currently provide only the original message body. Agents cannot identify the original speaker and may misattribute statements.

The optional Xquik section keeps Feishu messaging separate from X/Twitter automation.

## How To Test

- `pnpm install --frozen-lockfile --ignore-scripts`
- `npx tsc --noEmit`
- `npx vitest run --coverage --testTimeout=30000`
  - 23 files passed.
  - 144 tests passed.
  - 98.71% statements and 92.97% branches.
- `npm pack --dry-run --json`
- Render `README.md` through GitHub's Markdown API.
- Verify both new documentation links return HTTP 200.

## Impact (Optional)

Reply contexts now identify the original sender. No configuration or dependency changes are required. TweetClaw remains optional.

## Related (Optional)

- Closes #436
